### PR TITLE
Update reader.zig

### DIFF
--- a/src/reader.zig
+++ b/src/reader.zig
@@ -23,8 +23,8 @@ pub fn Reader(comptime S: type) type {
 
 		pub fn init(stream: S, timeout: i32) !Self {
 			const timeval = &std.mem.toBytes(std.posix.timeval{
-				.sec = @intCast(@divTrunc(timeout, 1000)),
-				.usec = @intCast(@mod(timeout, 1000) * 1000),
+				.tv_sec = @intCast(@divTrunc(timeout, 1000)),
+				.tv_usec = @intCast(@mod(timeout, 1000) * 1000),
 			});
 			try stream.readTimeout(timeval);
 


### PR DESCRIPTION
Error: no field named 'sec' in struct 'c.darwin.timeval'
    `.sec = @intCast(@divTrunc(timeout, 1000))`

zig version: 0.13.0