### PR TITLE
Add TLSv1.2 support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,6 @@
 # SMTP Client for Zig
 
-Zig only supports TLS 1.3. Furthermore, the TLS implementation [has known issues](https://github.com/ziglang/zig/issues/14172).
-
-This library does not work with Amazon SES as Amazon SES does not support TLS 1.3 (Amazon's documentation says that TLS 1.3 is supported with StartTLS but this does not appear to be the case (OpenSSL also reports an error)). 
+TLSv1.2 support code from https://github.com/melonedo/zig-tls12
 
 The library supports the `PLAIN`, `LOGIN` and `CRAM-MD5` mechanisms of the `AUTH` extension.
 

--- a/src/crypto/Bundle.zig
+++ b/src/crypto/Bundle.zig
@@ -1,0 +1,325 @@
+//! A set of certificates. Typically pre-installed on every operating system,
+//! these are "Certificate Authorities" used to validate SSL certificates.
+//! This data structure stores certificates in DER-encoded form, all of them
+//! concatenated together in the `bytes` array. The `map` field contains an
+//! index from the DER-encoded subject name to the index of the containing
+//! certificate within `bytes`.
+
+/// The key is the contents slice of the subject.
+map: std.HashMapUnmanaged(der.Element.Slice, u32, MapContext, std.hash_map.default_max_load_percentage) = .{},
+bytes: std.ArrayListUnmanaged(u8) = .{},
+
+pub const VerifyError = Certificate.Parsed.VerifyError || error{
+    CertificateIssuerNotFound,
+};
+
+pub fn verify(cb: Bundle, subject: Certificate.Parsed, now_sec: i64) VerifyError!void {
+    const bytes_index = cb.find(subject.issuer()) orelse return error.CertificateIssuerNotFound;
+    const issuer_cert: Certificate = .{
+        .buffer = cb.bytes.items,
+        .index = bytes_index,
+    };
+    // Every certificate in the bundle is pre-parsed before adding it, ensuring
+    // that parsing will succeed here.
+    const issuer = issuer_cert.parse() catch unreachable;
+    try subject.verify(issuer, now_sec);
+}
+
+/// The returned bytes become invalid after calling any of the rescan functions
+/// or add functions.
+pub fn find(cb: Bundle, subject_name: []const u8) ?u32 {
+    const Adapter = struct {
+        cb: Bundle,
+
+        pub fn hash(ctx: @This(), k: []const u8) u64 {
+            _ = ctx;
+            return std.hash_map.hashString(k);
+        }
+
+        pub fn eql(ctx: @This(), a: []const u8, b_key: der.Element.Slice) bool {
+            const b = ctx.cb.bytes.items[b_key.start..b_key.end];
+            return mem.eql(u8, a, b);
+        }
+    };
+    return cb.map.getAdapted(subject_name, Adapter{ .cb = cb });
+}
+
+pub fn deinit(cb: *Bundle, gpa: Allocator) void {
+    cb.map.deinit(gpa);
+    cb.bytes.deinit(gpa);
+    cb.* = undefined;
+}
+
+pub const RescanError = RescanLinuxError || RescanMacError || RescanBSDError || RescanWindowsError;
+
+/// Clears the set of certificates and then scans the host operating system
+/// file system standard locations for certificates.
+/// For operating systems that do not have standard CA installations to be
+/// found, this function clears the set of certificates.
+pub fn rescan(cb: *Bundle, gpa: Allocator) RescanError!void {
+    switch (builtin.os.tag) {
+        .linux => return rescanLinux(cb, gpa),
+        .macos => return rescanMac(cb, gpa),
+        .freebsd, .openbsd => return rescanBSD(cb, gpa, "/etc/ssl/cert.pem"),
+        .netbsd => return rescanBSD(cb, gpa, "/etc/openssl/certs/ca-certificates.crt"),
+        .dragonfly => return rescanBSD(cb, gpa, "/usr/local/etc/ssl/cert.pem"),
+        .solaris, .illumos => return rescanBSD(cb, gpa, "/etc/ssl/cacert.pem"),
+        .windows => return rescanWindows(cb, gpa),
+        else => {},
+    }
+}
+
+const rescanMac = @import("Bundle/macos.zig").rescanMac;
+const RescanMacError = @import("Bundle/macos.zig").RescanMacError;
+
+const RescanLinuxError = AddCertsFromFilePathError || AddCertsFromDirPathError;
+
+fn rescanLinux(cb: *Bundle, gpa: Allocator) RescanLinuxError!void {
+    // Possible certificate files; stop after finding one.
+    const cert_file_paths = [_][]const u8{
+        "/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu/Gentoo etc.
+        "/etc/pki/tls/certs/ca-bundle.crt", // Fedora/RHEL 6
+        "/etc/ssl/ca-bundle.pem", // OpenSUSE
+        "/etc/pki/tls/cacert.pem", // OpenELEC
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+        "/etc/ssl/cert.pem", // Alpine Linux
+    };
+
+    // Possible directories with certificate files; all will be read.
+    const cert_dir_paths = [_][]const u8{
+        "/etc/ssl/certs", // SLES10/SLES11
+        "/etc/pki/tls/certs", // Fedora/RHEL
+        "/system/etc/security/cacerts", // Android
+    };
+
+    cb.bytes.clearRetainingCapacity();
+    cb.map.clearRetainingCapacity();
+
+    scan: {
+        for (cert_file_paths) |cert_file_path| {
+            if (addCertsFromFilePathAbsolute(cb, gpa, cert_file_path)) |_| {
+                break :scan;
+            } else |err| switch (err) {
+                error.FileNotFound => continue,
+                else => |e| return e,
+            }
+        }
+
+        for (cert_dir_paths) |cert_dir_path| {
+            addCertsFromDirPathAbsolute(cb, gpa, cert_dir_path) catch |err| switch (err) {
+                error.FileNotFound => continue,
+                else => |e| return e,
+            };
+        }
+    }
+
+    cb.bytes.shrinkAndFree(gpa, cb.bytes.items.len);
+}
+
+const RescanBSDError = AddCertsFromFilePathError;
+
+fn rescanBSD(cb: *Bundle, gpa: Allocator, cert_file_path: []const u8) RescanBSDError!void {
+    cb.bytes.clearRetainingCapacity();
+    cb.map.clearRetainingCapacity();
+    try addCertsFromFilePathAbsolute(cb, gpa, cert_file_path);
+    cb.bytes.shrinkAndFree(gpa, cb.bytes.items.len);
+}
+
+const RescanWindowsError = Allocator.Error || ParseCertError || std.posix.UnexpectedError || error{FileNotFound};
+
+fn rescanWindows(cb: *Bundle, gpa: Allocator) RescanWindowsError!void {
+    cb.bytes.clearRetainingCapacity();
+    cb.map.clearRetainingCapacity();
+
+    const w = std.os.windows;
+    const GetLastError = w.kernel32.GetLastError;
+    const root = [4:0]u16{ 'R', 'O', 'O', 'T' };
+    const store = w.crypt32.CertOpenSystemStoreW(null, &root) orelse switch (GetLastError()) {
+        .FILE_NOT_FOUND => return error.FileNotFound,
+        else => |err| return w.unexpectedError(err),
+    };
+    defer _ = w.crypt32.CertCloseStore(store, 0);
+
+    const now_sec = std.time.timestamp();
+
+    var ctx = w.crypt32.CertEnumCertificatesInStore(store, null);
+    while (ctx) |context| : (ctx = w.crypt32.CertEnumCertificatesInStore(store, ctx)) {
+        const decoded_start = @as(u32, @intCast(cb.bytes.items.len));
+        const encoded_cert = context.pbCertEncoded[0..context.cbCertEncoded];
+        try cb.bytes.appendSlice(gpa, encoded_cert);
+        try cb.parseCert(gpa, decoded_start, now_sec);
+    }
+    cb.bytes.shrinkAndFree(gpa, cb.bytes.items.len);
+}
+
+pub const AddCertsFromDirPathError = fs.File.OpenError || AddCertsFromDirError;
+
+pub fn addCertsFromDirPath(
+    cb: *Bundle,
+    gpa: Allocator,
+    dir: fs.Dir,
+    sub_dir_path: []const u8,
+) AddCertsFromDirPathError!void {
+    var iterable_dir = try dir.openDir(sub_dir_path, .{ .iterate = true });
+    defer iterable_dir.close();
+    return addCertsFromDir(cb, gpa, iterable_dir);
+}
+
+pub fn addCertsFromDirPathAbsolute(
+    cb: *Bundle,
+    gpa: Allocator,
+    abs_dir_path: []const u8,
+) AddCertsFromDirPathError!void {
+    assert(fs.path.isAbsolute(abs_dir_path));
+    var iterable_dir = try fs.openDirAbsolute(abs_dir_path, .{ .iterate = true });
+    defer iterable_dir.close();
+    return addCertsFromDir(cb, gpa, iterable_dir);
+}
+
+pub const AddCertsFromDirError = AddCertsFromFilePathError;
+
+pub fn addCertsFromDir(cb: *Bundle, gpa: Allocator, iterable_dir: fs.Dir) AddCertsFromDirError!void {
+    var it = iterable_dir.iterate();
+    while (try it.next()) |entry| {
+        switch (entry.kind) {
+            .file, .sym_link => {},
+            else => continue,
+        }
+
+        try addCertsFromFilePath(cb, gpa, iterable_dir, entry.name);
+    }
+}
+
+pub const AddCertsFromFilePathError = fs.File.OpenError || AddCertsFromFileError;
+
+pub fn addCertsFromFilePathAbsolute(
+    cb: *Bundle,
+    gpa: Allocator,
+    abs_file_path: []const u8,
+) AddCertsFromFilePathError!void {
+    assert(fs.path.isAbsolute(abs_file_path));
+    var file = try fs.openFileAbsolute(abs_file_path, .{});
+    defer file.close();
+    return addCertsFromFile(cb, gpa, file);
+}
+
+pub fn addCertsFromFilePath(
+    cb: *Bundle,
+    gpa: Allocator,
+    dir: fs.Dir,
+    sub_file_path: []const u8,
+) AddCertsFromFilePathError!void {
+    var file = try dir.openFile(sub_file_path, .{});
+    defer file.close();
+    return addCertsFromFile(cb, gpa, file);
+}
+
+pub const AddCertsFromFileError = Allocator.Error ||
+    fs.File.GetSeekPosError ||
+    fs.File.ReadError ||
+    ParseCertError ||
+    std.base64.Error ||
+    error{ CertificateAuthorityBundleTooBig, MissingEndCertificateMarker };
+
+pub fn addCertsFromFile(cb: *Bundle, gpa: Allocator, file: fs.File) AddCertsFromFileError!void {
+    const size = try file.getEndPos();
+
+    // We borrow `bytes` as a temporary buffer for the base64-encoded data.
+    // This is possible by computing the decoded length and reserving the space
+    // for the decoded bytes first.
+    const decoded_size_upper_bound = size / 4 * 3;
+    const needed_capacity = std.math.cast(u32, decoded_size_upper_bound + size) orelse
+        return error.CertificateAuthorityBundleTooBig;
+    try cb.bytes.ensureUnusedCapacity(gpa, needed_capacity);
+    const end_reserved: u32 = @intCast(cb.bytes.items.len + decoded_size_upper_bound);
+    const buffer = cb.bytes.allocatedSlice()[end_reserved..];
+    const end_index = try file.readAll(buffer);
+    const encoded_bytes = buffer[0..end_index];
+
+    const begin_marker = "-----BEGIN CERTIFICATE-----";
+    const end_marker = "-----END CERTIFICATE-----";
+
+    const now_sec = std.time.timestamp();
+
+    var start_index: usize = 0;
+    while (mem.indexOfPos(u8, encoded_bytes, start_index, begin_marker)) |begin_marker_start| {
+        const cert_start = begin_marker_start + begin_marker.len;
+        const cert_end = mem.indexOfPos(u8, encoded_bytes, cert_start, end_marker) orelse
+            return error.MissingEndCertificateMarker;
+        start_index = cert_end + end_marker.len;
+        const encoded_cert = mem.trim(u8, encoded_bytes[cert_start..cert_end], " \t\r\n");
+        const decoded_start: u32 = @intCast(cb.bytes.items.len);
+        const dest_buf = cb.bytes.allocatedSlice()[decoded_start..];
+        cb.bytes.items.len += try base64.decode(dest_buf, encoded_cert);
+        try cb.parseCert(gpa, decoded_start, now_sec);
+    }
+}
+
+pub const ParseCertError = Allocator.Error || Certificate.ParseError;
+
+pub fn parseCert(cb: *Bundle, gpa: Allocator, decoded_start: u32, now_sec: i64) ParseCertError!void {
+    // Even though we could only partially parse the certificate to find
+    // the subject name, we pre-parse all of them to make sure and only
+    // include in the bundle ones that we know will parse. This way we can
+    // use `catch unreachable` later.
+    const parsed_cert = Certificate.parse(.{
+        .buffer = cb.bytes.items,
+        .index = decoded_start,
+    }) catch |err| switch (err) {
+        error.CertificateHasUnrecognizedObjectId => {
+            cb.bytes.items.len = decoded_start;
+            return;
+        },
+        else => |e| return e,
+    };
+    if (now_sec > parsed_cert.validity.not_after) {
+        // Ignore expired cert.
+        cb.bytes.items.len = decoded_start;
+        return;
+    }
+    const gop = try cb.map.getOrPutContext(gpa, parsed_cert.subject_slice, .{ .cb = cb });
+    if (gop.found_existing) {
+        cb.bytes.items.len = decoded_start;
+    } else {
+        gop.value_ptr.* = decoded_start;
+    }
+}
+
+const builtin = @import("builtin");
+const std = @import("std");
+const assert = std.debug.assert;
+const fs = std.fs;
+const mem = std.mem;
+const crypto = std.crypto;
+const Allocator = std.mem.Allocator;
+const Certificate = @import("Certificate.zig");
+const der = Certificate.der;
+const Bundle = @This();
+
+const base64 = std.base64.standard.decoderWithIgnore(" \t\r\n");
+
+const MapContext = struct {
+    cb: *const Bundle,
+
+    pub fn hash(ctx: MapContext, k: der.Element.Slice) u64 {
+        return std.hash_map.hashString(ctx.cb.bytes.items[k.start..k.end]);
+    }
+
+    pub fn eql(ctx: MapContext, a: der.Element.Slice, b: der.Element.Slice) bool {
+        const bytes = ctx.cb.bytes.items;
+        return mem.eql(
+            u8,
+            bytes[a.start..a.end],
+            bytes[b.start..b.end],
+        );
+    }
+};
+
+test "scan for OS-provided certificates" {
+    if (builtin.os.tag == .wasi) return error.SkipZigTest;
+
+    var bundle: Bundle = .{};
+    defer bundle.deinit(std.testing.allocator);
+
+    try bundle.rescan(std.testing.allocator);
+}

--- a/src/crypto/Bundle/macos.zig
+++ b/src/crypto/Bundle/macos.zig
@@ -1,0 +1,114 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const fs = std.fs;
+const mem = std.mem;
+const Allocator = std.mem.Allocator;
+const Bundle = @import("../Bundle.zig");
+
+pub const RescanMacError = Allocator.Error || fs.File.OpenError || fs.File.ReadError || fs.File.SeekError || Bundle.ParseCertError || error{EndOfStream};
+
+pub fn rescanMac(cb: *Bundle, gpa: Allocator) RescanMacError!void {
+    cb.bytes.clearRetainingCapacity();
+    cb.map.clearRetainingCapacity();
+
+    const file = try fs.openFileAbsolute("/System/Library/Keychains/SystemRootCertificates.keychain", .{});
+    defer file.close();
+
+    const bytes = try file.readToEndAlloc(gpa, std.math.maxInt(u32));
+    defer gpa.free(bytes);
+
+    var stream = std.io.fixedBufferStream(bytes);
+    const reader = stream.reader();
+
+    const db_header = try reader.readStructEndian(ApplDbHeader, .big);
+    assert(mem.eql(u8, "kych", &@as([4]u8, @bitCast(db_header.signature))));
+
+    try stream.seekTo(db_header.schema_offset);
+
+    const db_schema = try reader.readStructEndian(ApplDbSchema, .big);
+
+    var table_list = try gpa.alloc(u32, db_schema.table_count);
+    defer gpa.free(table_list);
+
+    var table_idx: u32 = 0;
+    while (table_idx < table_list.len) : (table_idx += 1) {
+        table_list[table_idx] = try reader.readInt(u32, .big);
+    }
+
+    const now_sec = std.time.timestamp();
+
+    for (table_list) |table_offset| {
+        try stream.seekTo(db_header.schema_offset + table_offset);
+
+        const table_header = try reader.readStructEndian(TableHeader, .big);
+
+        if (@as(std.c.cssm.DB_RECORDTYPE, @enumFromInt(table_header.table_id)) != .X509_CERTIFICATE) {
+            continue;
+        }
+
+        var record_list = try gpa.alloc(u32, table_header.record_count);
+        defer gpa.free(record_list);
+
+        var record_idx: u32 = 0;
+        while (record_idx < record_list.len) : (record_idx += 1) {
+            record_list[record_idx] = try reader.readInt(u32, .big);
+        }
+
+        for (record_list) |record_offset| {
+            try stream.seekTo(db_header.schema_offset + table_offset + record_offset);
+
+            const cert_header = try reader.readStructEndian(X509CertHeader, .big);
+
+            try cb.bytes.ensureUnusedCapacity(gpa, cert_header.cert_size);
+
+            const cert_start = @as(u32, @intCast(cb.bytes.items.len));
+            const dest_buf = cb.bytes.allocatedSlice()[cert_start..];
+            cb.bytes.items.len += try reader.readAtLeast(dest_buf, cert_header.cert_size);
+
+            try cb.parseCert(gpa, cert_start, now_sec);
+        }
+    }
+
+    cb.bytes.shrinkAndFree(gpa, cb.bytes.items.len);
+}
+
+const ApplDbHeader = extern struct {
+    signature: @Vector(4, u8),
+    version: u32,
+    header_size: u32,
+    schema_offset: u32,
+    auth_offset: u32,
+};
+
+const ApplDbSchema = extern struct {
+    schema_size: u32,
+    table_count: u32,
+};
+
+const TableHeader = extern struct {
+    table_size: u32,
+    table_id: u32,
+    record_count: u32,
+    records: u32,
+    indexes_offset: u32,
+    free_list_head: u32,
+    record_numbers_count: u32,
+};
+
+const X509CertHeader = extern struct {
+    record_size: u32,
+    record_number: u32,
+    unknown1: u32,
+    unknown2: u32,
+    cert_size: u32,
+    unknown3: u32,
+    cert_type: u32,
+    cert_encoding: u32,
+    print_name: u32,
+    alias: u32,
+    subject: u32,
+    issuer: u32,
+    serial_number: u32,
+    subject_key_identifier: u32,
+    public_key_hash: u32,
+};

--- a/src/crypto/Certificate.zig
+++ b/src/crypto/Certificate.zig
@@ -1,0 +1,1162 @@
+buffer: []const u8,
+index: u32,
+const std = @import("std");
+const StaticStringMap = std.static_string_map.StaticStringMap;
+pub const Bundle = @import("Bundle.zig");
+
+pub const Version = enum { v1, v2, v3 };
+
+pub const Algorithm = enum {
+    sha1WithRSAEncryption,
+    sha224WithRSAEncryption,
+    sha256WithRSAEncryption,
+    sha384WithRSAEncryption,
+    sha512WithRSAEncryption,
+    ecdsa_with_SHA224,
+    ecdsa_with_SHA256,
+    ecdsa_with_SHA384,
+    ecdsa_with_SHA512,
+    md2WithRSAEncryption,
+    md5WithRSAEncryption,
+
+    pub const map = StaticStringMap(Algorithm).initComptime(.{
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x05 }, .sha1WithRSAEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x0B }, .sha256WithRSAEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x0C }, .sha384WithRSAEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x0D }, .sha512WithRSAEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x0E }, .sha224WithRSAEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x01 }, .ecdsa_with_SHA224 },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x02 }, .ecdsa_with_SHA256 },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x03 }, .ecdsa_with_SHA384 },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x04, 0x03, 0x04 }, .ecdsa_with_SHA512 },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x02 }, .md2WithRSAEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x04 }, .md5WithRSAEncryption },
+    });
+
+    pub fn Hash(comptime algorithm: Algorithm) type {
+        return switch (algorithm) {
+            .sha1WithRSAEncryption => crypto.hash.Sha1,
+            .ecdsa_with_SHA224, .sha224WithRSAEncryption => crypto.hash.sha2.Sha224,
+            .ecdsa_with_SHA256, .sha256WithRSAEncryption => crypto.hash.sha2.Sha256,
+            .ecdsa_with_SHA384, .sha384WithRSAEncryption => crypto.hash.sha2.Sha384,
+            .ecdsa_with_SHA512, .sha512WithRSAEncryption => crypto.hash.sha2.Sha512,
+            .md2WithRSAEncryption => @compileError("unimplemented"),
+            .md5WithRSAEncryption => crypto.hash.Md5,
+        };
+    }
+};
+
+pub const AlgorithmCategory = enum {
+    rsaEncryption,
+    X9_62_id_ecPublicKey,
+
+    pub const map = StaticStringMap(AlgorithmCategory).initComptime(.{
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01 }, .rsaEncryption },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01 }, .X9_62_id_ecPublicKey },
+    });
+};
+
+pub const Attribute = enum {
+    commonName,
+    serialNumber,
+    countryName,
+    localityName,
+    stateOrProvinceName,
+    streetAddress,
+    organizationName,
+    organizationalUnitName,
+    postalCode,
+    organizationIdentifier,
+    pkcs9_emailAddress,
+    domainComponent,
+
+    pub const map = StaticStringMap(Attribute).initComptime(.{
+        .{ &[_]u8{ 0x55, 0x04, 0x03 }, .commonName },
+        .{ &[_]u8{ 0x55, 0x04, 0x05 }, .serialNumber },
+        .{ &[_]u8{ 0x55, 0x04, 0x06 }, .countryName },
+        .{ &[_]u8{ 0x55, 0x04, 0x07 }, .localityName },
+        .{ &[_]u8{ 0x55, 0x04, 0x08 }, .stateOrProvinceName },
+        .{ &[_]u8{ 0x55, 0x04, 0x09 }, .streetAddress },
+        .{ &[_]u8{ 0x55, 0x04, 0x0A }, .organizationName },
+        .{ &[_]u8{ 0x55, 0x04, 0x0B }, .organizationalUnitName },
+        .{ &[_]u8{ 0x55, 0x04, 0x11 }, .postalCode },
+        .{ &[_]u8{ 0x55, 0x04, 0x61 }, .organizationIdentifier },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x09, 0x01 }, .pkcs9_emailAddress },
+        .{ &[_]u8{ 0x09, 0x92, 0x26, 0x89, 0x93, 0xF2, 0x2C, 0x64, 0x01, 0x19 }, .domainComponent },
+    });
+};
+
+pub const NamedCurve = enum {
+    secp384r1,
+    secp521r1,
+    X9_62_prime256v1,
+
+    pub const map = StaticStringMap(NamedCurve).initComptime(.{
+        .{ &[_]u8{ 0x2B, 0x81, 0x04, 0x00, 0x22 }, .secp384r1 },
+        .{ &[_]u8{ 0x2B, 0x81, 0x04, 0x00, 0x23 }, .secp521r1 },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07 }, .X9_62_prime256v1 },
+    });
+
+    pub fn Curve(comptime curve: NamedCurve) type {
+        return switch (curve) {
+            .X9_62_prime256v1 => crypto.ecc.P256,
+            .secp384r1 => crypto.ecc.P384,
+            .secp521r1 => @compileError("unimplemented"),
+        };
+    }
+};
+
+pub const ExtensionId = enum {
+    subject_key_identifier,
+    key_usage,
+    private_key_usage_period,
+    subject_alt_name,
+    issuer_alt_name,
+    basic_constraints,
+    crl_number,
+    certificate_policies,
+    authority_key_identifier,
+    msCertsrvCAVersion,
+    commonName,
+    ext_key_usage,
+    crl_distribution_points,
+    info_access,
+    entrustVersInfo,
+    enroll_certtype,
+    pe_logotype,
+    netscape_cert_type,
+    netscape_comment,
+
+    pub const map = StaticStringMap(ExtensionId).initComptime(.{
+        .{ &[_]u8{ 0x55, 0x04, 0x03 }, .commonName },
+        .{ &[_]u8{ 0x55, 0x1D, 0x01 }, .authority_key_identifier },
+        .{ &[_]u8{ 0x55, 0x1D, 0x07 }, .subject_alt_name },
+        .{ &[_]u8{ 0x55, 0x1D, 0x0E }, .subject_key_identifier },
+        .{ &[_]u8{ 0x55, 0x1D, 0x0F }, .key_usage },
+        .{ &[_]u8{ 0x55, 0x1D, 0x0A }, .basic_constraints },
+        .{ &[_]u8{ 0x55, 0x1D, 0x10 }, .private_key_usage_period },
+        .{ &[_]u8{ 0x55, 0x1D, 0x11 }, .subject_alt_name },
+        .{ &[_]u8{ 0x55, 0x1D, 0x12 }, .issuer_alt_name },
+        .{ &[_]u8{ 0x55, 0x1D, 0x13 }, .basic_constraints },
+        .{ &[_]u8{ 0x55, 0x1D, 0x14 }, .crl_number },
+        .{ &[_]u8{ 0x55, 0x1D, 0x1F }, .crl_distribution_points },
+        .{ &[_]u8{ 0x55, 0x1D, 0x20 }, .certificate_policies },
+        .{ &[_]u8{ 0x55, 0x1D, 0x23 }, .authority_key_identifier },
+        .{ &[_]u8{ 0x55, 0x1D, 0x25 }, .ext_key_usage },
+        .{ &[_]u8{ 0x2B, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x15, 0x01 }, .msCertsrvCAVersion },
+        .{ &[_]u8{ 0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x01, 0x01 }, .info_access },
+        .{ &[_]u8{ 0x2A, 0x86, 0x48, 0x86, 0xF6, 0x7D, 0x07, 0x41, 0x00 }, .entrustVersInfo },
+        .{ &[_]u8{ 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x14, 0x02 }, .enroll_certtype },
+        .{ &[_]u8{ 0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x01, 0x0c }, .pe_logotype },
+        .{ &[_]u8{ 0x60, 0x86, 0x48, 0x01, 0x86, 0xf8, 0x42, 0x01, 0x01 }, .netscape_cert_type },
+        .{ &[_]u8{ 0x60, 0x86, 0x48, 0x01, 0x86, 0xf8, 0x42, 0x01, 0x0d }, .netscape_comment },
+    });
+};
+
+pub const GeneralNameTag = enum(u5) {
+    otherName = 0,
+    rfc822Name = 1,
+    dNSName = 2,
+    x400Address = 3,
+    directoryName = 4,
+    ediPartyName = 5,
+    uniformResourceIdentifier = 6,
+    iPAddress = 7,
+    registeredID = 8,
+    _,
+};
+
+pub const Parsed = struct {
+    certificate: Certificate,
+    issuer_slice: Slice,
+    subject_slice: Slice,
+    common_name_slice: Slice,
+    signature_slice: Slice,
+    signature_algorithm: Algorithm,
+    pub_key_algo: PubKeyAlgo,
+    pub_key_slice: Slice,
+    message_slice: Slice,
+    subject_alt_name_slice: Slice,
+    validity: Validity,
+    version: Version,
+
+    pub const PubKeyAlgo = union(AlgorithmCategory) {
+        rsaEncryption: void,
+        X9_62_id_ecPublicKey: NamedCurve,
+    };
+
+    pub const Validity = struct {
+        not_before: u64,
+        not_after: u64,
+    };
+
+    pub const Slice = der.Element.Slice;
+
+    pub fn slice(p: Parsed, s: Slice) []const u8 {
+        return p.certificate.buffer[s.start..s.end];
+    }
+
+    pub fn issuer(p: Parsed) []const u8 {
+        return p.slice(p.issuer_slice);
+    }
+
+    pub fn subject(p: Parsed) []const u8 {
+        return p.slice(p.subject_slice);
+    }
+
+    pub fn commonName(p: Parsed) []const u8 {
+        return p.slice(p.common_name_slice);
+    }
+
+    pub fn signature(p: Parsed) []const u8 {
+        return p.slice(p.signature_slice);
+    }
+
+    pub fn pubKey(p: Parsed) []const u8 {
+        return p.slice(p.pub_key_slice);
+    }
+
+    pub fn pubKeySigAlgo(p: Parsed) []const u8 {
+        return p.slice(p.pub_key_signature_algorithm_slice);
+    }
+
+    pub fn message(p: Parsed) []const u8 {
+        return p.slice(p.message_slice);
+    }
+
+    pub fn subjectAltName(p: Parsed) []const u8 {
+        return p.slice(p.subject_alt_name_slice);
+    }
+
+    pub const VerifyError = error{
+        CertificateIssuerMismatch,
+        CertificateNotYetValid,
+        CertificateExpired,
+        CertificateSignatureAlgorithmUnsupported,
+        CertificateSignatureAlgorithmMismatch,
+        CertificateFieldHasInvalidLength,
+        CertificateFieldHasWrongDataType,
+        CertificatePublicKeyInvalid,
+        CertificateSignatureInvalidLength,
+        CertificateSignatureInvalid,
+        CertificateSignatureUnsupportedBitCount,
+        CertificateSignatureNamedCurveUnsupported,
+    };
+
+    /// This function verifies:
+    ///  * That the subject's issuer is indeed the provided issuer.
+    ///  * The time validity of the subject.
+    ///  * The signature.
+    pub fn verify(parsed_subject: Parsed, parsed_issuer: Parsed, now_sec: i64) VerifyError!void {
+        // Check that the subject's issuer name matches the issuer's
+        // subject name.
+        if (!mem.eql(u8, parsed_subject.issuer(), parsed_issuer.subject())) {
+            return error.CertificateIssuerMismatch;
+        }
+
+        if (now_sec < parsed_subject.validity.not_before)
+            return error.CertificateNotYetValid;
+        if (now_sec > parsed_subject.validity.not_after)
+            return error.CertificateExpired;
+
+        switch (parsed_subject.signature_algorithm) {
+            inline .sha1WithRSAEncryption,
+            .sha224WithRSAEncryption,
+            .sha256WithRSAEncryption,
+            .sha384WithRSAEncryption,
+            .sha512WithRSAEncryption,
+            => |algorithm| return verifyRsa(
+                algorithm.Hash(),
+                parsed_subject.message(),
+                parsed_subject.signature(),
+                parsed_issuer.pub_key_algo,
+                parsed_issuer.pubKey(),
+            ),
+
+            inline .ecdsa_with_SHA224,
+            .ecdsa_with_SHA256,
+            .ecdsa_with_SHA384,
+            .ecdsa_with_SHA512,
+            => |algorithm| return verify_ecdsa(
+                algorithm.Hash(),
+                parsed_subject.message(),
+                parsed_subject.signature(),
+                parsed_issuer.pub_key_algo,
+                parsed_issuer.pubKey(),
+            ),
+
+            .md2WithRSAEncryption, .md5WithRSAEncryption => {
+                return error.CertificateSignatureAlgorithmUnsupported;
+            },
+        }
+    }
+
+    pub const VerifyHostNameError = error{
+        CertificateHostMismatch,
+        CertificateFieldHasInvalidLength,
+    };
+
+    pub fn verifyHostName(parsed_subject: Parsed, host_name: []const u8) VerifyHostNameError!void {
+        // If the Subject Alternative Names extension is present, this is
+        // what to check. Otherwise, only the common name is checked.
+        const subject_alt_name = parsed_subject.subjectAltName();
+        if (subject_alt_name.len == 0) {
+            if (checkHostName(host_name, parsed_subject.commonName())) {
+                return;
+            } else {
+                return error.CertificateHostMismatch;
+            }
+        }
+
+        const general_names = try der.Element.parse(subject_alt_name, 0);
+        var name_i = general_names.slice.start;
+        while (name_i < general_names.slice.end) {
+            const general_name = try der.Element.parse(subject_alt_name, name_i);
+            name_i = general_name.slice.end;
+            switch (@as(GeneralNameTag, @enumFromInt(@intFromEnum(general_name.identifier.tag)))) {
+                .dNSName => {
+                    const dns_name = subject_alt_name[general_name.slice.start..general_name.slice.end];
+                    if (checkHostName(host_name, dns_name)) return;
+                },
+                else => {},
+            }
+        }
+
+        return error.CertificateHostMismatch;
+    }
+
+    // Check hostname according to RFC2818 specification:
+    //
+    // If more than one identity of a given type is present in
+    // the certificate (e.g., more than one DNSName name, a match in any one
+    // of the set is considered acceptable.) Names may contain the wildcard
+    // character * which is considered to match any single domain name
+    // component or component fragment. E.g., *.a.com matches foo.a.com but
+    // not bar.foo.a.com. f*.com matches foo.com but not bar.com.
+    fn checkHostName(host_name: []const u8, dns_name: []const u8) bool {
+        if (mem.eql(u8, dns_name, host_name)) {
+            return true; // exact match
+        }
+
+        var it_host = std.mem.splitScalar(u8, host_name, '.');
+        var it_dns = std.mem.splitScalar(u8, dns_name, '.');
+
+        const len_match = while (true) {
+            const host = it_host.next();
+            const dns = it_dns.next();
+
+            if (host == null or dns == null) {
+                break host == null and dns == null;
+            }
+
+            // If not a wildcard and they dont
+            // match then there is no match.
+            if (mem.eql(u8, dns.?, "*") == false and mem.eql(u8, dns.?, host.?) == false) {
+                return false;
+            }
+        };
+
+        // If the components are not the same
+        // length then there is no match.
+        return len_match;
+    }
+};
+
+test "Parsed.checkHostName" {
+    const expectEqual = std.testing.expectEqual;
+
+    try expectEqual(true, Parsed.checkHostName("ziglang.org", "ziglang.org"));
+    try expectEqual(true, Parsed.checkHostName("bar.ziglang.org", "*.ziglang.org"));
+    try expectEqual(false, Parsed.checkHostName("foo.bar.ziglang.org", "*.ziglang.org"));
+    try expectEqual(false, Parsed.checkHostName("ziglang.org", "zig*.org"));
+    try expectEqual(false, Parsed.checkHostName("lang.org", "zig*.org"));
+}
+
+pub const ParseError = der.Element.ParseElementError || ParseVersionError || ParseTimeError || ParseEnumError || ParseBitStringError;
+
+pub fn parse(cert: Certificate) ParseError!Parsed {
+    const cert_bytes = cert.buffer;
+    const certificate = try der.Element.parse(cert_bytes, cert.index);
+    const tbs_certificate = try der.Element.parse(cert_bytes, certificate.slice.start);
+    const version_elem = try der.Element.parse(cert_bytes, tbs_certificate.slice.start);
+    const version = try parseVersion(cert_bytes, version_elem);
+    const serial_number = if (@as(u8, @bitCast(version_elem.identifier)) == 0xa0)
+        try der.Element.parse(cert_bytes, version_elem.slice.end)
+    else
+        version_elem;
+    // RFC 5280, section 4.1.2.3:
+    // "This field MUST contain the same algorithm identifier as
+    // the signatureAlgorithm field in the sequence Certificate."
+    const tbs_signature = try der.Element.parse(cert_bytes, serial_number.slice.end);
+    const issuer = try der.Element.parse(cert_bytes, tbs_signature.slice.end);
+    const validity = try der.Element.parse(cert_bytes, issuer.slice.end);
+    const not_before = try der.Element.parse(cert_bytes, validity.slice.start);
+    const not_before_utc = try parseTime(cert, not_before);
+    const not_after = try der.Element.parse(cert_bytes, not_before.slice.end);
+    const not_after_utc = try parseTime(cert, not_after);
+    const subject = try der.Element.parse(cert_bytes, validity.slice.end);
+
+    const pub_key_info = try der.Element.parse(cert_bytes, subject.slice.end);
+    const pub_key_signature_algorithm = try der.Element.parse(cert_bytes, pub_key_info.slice.start);
+    const pub_key_algo_elem = try der.Element.parse(cert_bytes, pub_key_signature_algorithm.slice.start);
+    const pub_key_algo_tag = try parseAlgorithmCategory(cert_bytes, pub_key_algo_elem);
+    var pub_key_algo: Parsed.PubKeyAlgo = undefined;
+    switch (pub_key_algo_tag) {
+        .rsaEncryption => {
+            pub_key_algo = .{ .rsaEncryption = {} };
+        },
+        .X9_62_id_ecPublicKey => {
+            // RFC 5480 Section 2.1.1.1 Named Curve
+            // ECParameters ::= CHOICE {
+            //   namedCurve         OBJECT IDENTIFIER
+            //   -- implicitCurve   NULL
+            //   -- specifiedCurve  SpecifiedECDomain
+            // }
+            const params_elem = try der.Element.parse(cert_bytes, pub_key_algo_elem.slice.end);
+            const named_curve = try parseNamedCurve(cert_bytes, params_elem);
+            pub_key_algo = .{ .X9_62_id_ecPublicKey = named_curve };
+        },
+    }
+    const pub_key_elem = try der.Element.parse(cert_bytes, pub_key_signature_algorithm.slice.end);
+    const pub_key = try parseBitString(cert, pub_key_elem);
+
+    var common_name = der.Element.Slice.empty;
+    var name_i = subject.slice.start;
+    while (name_i < subject.slice.end) {
+        const rdn = try der.Element.parse(cert_bytes, name_i);
+        var rdn_i = rdn.slice.start;
+        while (rdn_i < rdn.slice.end) {
+            const atav = try der.Element.parse(cert_bytes, rdn_i);
+            var atav_i = atav.slice.start;
+            while (atav_i < atav.slice.end) {
+                const ty_elem = try der.Element.parse(cert_bytes, atav_i);
+                const val = try der.Element.parse(cert_bytes, ty_elem.slice.end);
+                atav_i = val.slice.end;
+                const ty = parseAttribute(cert_bytes, ty_elem) catch |err| switch (err) {
+                    error.CertificateHasUnrecognizedObjectId => continue,
+                    else => |e| return e,
+                };
+                switch (ty) {
+                    .commonName => common_name = val.slice,
+                    else => {},
+                }
+            }
+            rdn_i = atav.slice.end;
+        }
+        name_i = rdn.slice.end;
+    }
+
+    const sig_algo = try der.Element.parse(cert_bytes, tbs_certificate.slice.end);
+    const algo_elem = try der.Element.parse(cert_bytes, sig_algo.slice.start);
+    const signature_algorithm = try parseAlgorithm(cert_bytes, algo_elem);
+    const sig_elem = try der.Element.parse(cert_bytes, sig_algo.slice.end);
+    const signature = try parseBitString(cert, sig_elem);
+
+    // Extensions
+    var subject_alt_name_slice = der.Element.Slice.empty;
+    ext: {
+        if (version == .v1)
+            break :ext;
+
+        if (pub_key_info.slice.end >= tbs_certificate.slice.end)
+            break :ext;
+
+        const outer_extensions = try der.Element.parse(cert_bytes, pub_key_info.slice.end);
+        if (outer_extensions.identifier.tag != .bitstring)
+            break :ext;
+
+        const extensions = try der.Element.parse(cert_bytes, outer_extensions.slice.start);
+
+        var ext_i = extensions.slice.start;
+        while (ext_i < extensions.slice.end) {
+            const extension = try der.Element.parse(cert_bytes, ext_i);
+            ext_i = extension.slice.end;
+            const oid_elem = try der.Element.parse(cert_bytes, extension.slice.start);
+            const ext_id = parseExtensionId(cert_bytes, oid_elem) catch |err| switch (err) {
+                error.CertificateHasUnrecognizedObjectId => continue,
+                else => |e| return e,
+            };
+            const critical_elem = try der.Element.parse(cert_bytes, oid_elem.slice.end);
+            const ext_bytes_elem = if (critical_elem.identifier.tag != .boolean)
+                critical_elem
+            else
+                try der.Element.parse(cert_bytes, critical_elem.slice.end);
+            switch (ext_id) {
+                .subject_alt_name => subject_alt_name_slice = ext_bytes_elem.slice,
+                else => continue,
+            }
+        }
+    }
+
+    return .{
+        .certificate = cert,
+        .common_name_slice = common_name,
+        .issuer_slice = issuer.slice,
+        .subject_slice = subject.slice,
+        .signature_slice = signature,
+        .signature_algorithm = signature_algorithm,
+        .message_slice = .{ .start = certificate.slice.start, .end = tbs_certificate.slice.end },
+        .pub_key_algo = pub_key_algo,
+        .pub_key_slice = pub_key,
+        .validity = .{
+            .not_before = not_before_utc,
+            .not_after = not_after_utc,
+        },
+        .subject_alt_name_slice = subject_alt_name_slice,
+        .version = version,
+    };
+}
+
+pub fn verify(subject: Certificate, issuer: Certificate, now_sec: i64) !void {
+    const parsed_subject = try subject.parse();
+    const parsed_issuer = try issuer.parse();
+    return parsed_subject.verify(parsed_issuer, now_sec);
+}
+
+pub fn contents(cert: Certificate, elem: der.Element) []const u8 {
+    return cert.buffer[elem.slice.start..elem.slice.end];
+}
+
+pub const ParseBitStringError = error{ CertificateFieldHasWrongDataType, CertificateHasInvalidBitString };
+
+pub fn parseBitString(cert: Certificate, elem: der.Element) !der.Element.Slice {
+    if (elem.identifier.tag != .bitstring) return error.CertificateFieldHasWrongDataType;
+    if (cert.buffer[elem.slice.start] != 0) return error.CertificateHasInvalidBitString;
+    return .{ .start = elem.slice.start + 1, .end = elem.slice.end };
+}
+
+pub const ParseTimeError = error{ CertificateTimeInvalid, CertificateFieldHasWrongDataType };
+
+/// Returns number of seconds since epoch.
+pub fn parseTime(cert: Certificate, elem: der.Element) ParseTimeError!u64 {
+    const bytes = cert.contents(elem);
+    switch (elem.identifier.tag) {
+        .utc_time => {
+            // Example: "YYMMDD000000Z"
+            if (bytes.len != 13)
+                return error.CertificateTimeInvalid;
+            if (bytes[12] != 'Z')
+                return error.CertificateTimeInvalid;
+
+            return Date.toSeconds(.{
+                .year = @as(u16, 2000) + try parseTimeDigits(bytes[0..2], 0, 99),
+                .month = try parseTimeDigits(bytes[2..4], 1, 12),
+                .day = try parseTimeDigits(bytes[4..6], 1, 31),
+                .hour = try parseTimeDigits(bytes[6..8], 0, 23),
+                .minute = try parseTimeDigits(bytes[8..10], 0, 59),
+                .second = try parseTimeDigits(bytes[10..12], 0, 59),
+            });
+        },
+        .generalized_time => {
+            // Examples:
+            // "19920521000000Z"
+            // "19920622123421Z"
+            // "19920722132100.3Z"
+            if (bytes.len < 15)
+                return error.CertificateTimeInvalid;
+            return Date.toSeconds(.{
+                .year = try parseYear4(bytes[0..4]),
+                .month = try parseTimeDigits(bytes[4..6], 1, 12),
+                .day = try parseTimeDigits(bytes[6..8], 1, 31),
+                .hour = try parseTimeDigits(bytes[8..10], 0, 23),
+                .minute = try parseTimeDigits(bytes[10..12], 0, 59),
+                .second = try parseTimeDigits(bytes[12..14], 0, 59),
+            });
+        },
+        else => return error.CertificateFieldHasWrongDataType,
+    }
+}
+
+const Date = struct {
+    /// example: 1999
+    year: u16,
+    /// range: 1 to 12
+    month: u8,
+    /// range: 1 to 31
+    day: u8,
+    /// range: 0 to 59
+    hour: u8,
+    /// range: 0 to 59
+    minute: u8,
+    /// range: 0 to 59
+    second: u8,
+
+    /// Convert to number of seconds since epoch.
+    pub fn toSeconds(date: Date) u64 {
+        var sec: u64 = 0;
+
+        {
+            var year: u16 = 1970;
+            while (year < date.year) : (year += 1) {
+                const days: u64 = std.time.epoch.getDaysInYear(year);
+                sec += days * std.time.epoch.secs_per_day;
+            }
+        }
+
+        {
+            const is_leap = std.time.epoch.isLeapYear(date.year);
+            var month: u4 = 1;
+            while (month < date.month) : (month += 1) {
+                const days: u64 = std.time.epoch.getDaysInMonth(
+                    @as(std.time.epoch.YearLeapKind, @enumFromInt(@intFromBool(is_leap))),
+                    @as(std.time.epoch.Month, @enumFromInt(month)),
+                );
+                sec += days * std.time.epoch.secs_per_day;
+            }
+        }
+
+        sec += (date.day - 1) * @as(u64, std.time.epoch.secs_per_day);
+        sec += date.hour * @as(u64, 60 * 60);
+        sec += date.minute * @as(u64, 60);
+        sec += date.second;
+
+        return sec;
+    }
+};
+
+pub fn parseTimeDigits(text: *const [2]u8, min: u8, max: u8) !u8 {
+    const result = if (use_vectors) result: {
+        const nn: @Vector(2, u16) = .{ text[0], text[1] };
+        const zero: @Vector(2, u16) = .{ '0', '0' };
+        const mm: @Vector(2, u16) = .{ 10, 1 };
+        break :result @reduce(.Add, (nn -% zero) *% mm);
+    } else std.fmt.parseInt(u8, text, 10) catch return error.CertificateTimeInvalid;
+    if (result < min) return error.CertificateTimeInvalid;
+    if (result > max) return error.CertificateTimeInvalid;
+    return @truncate(result);
+}
+
+test parseTimeDigits {
+    const expectEqual = std.testing.expectEqual;
+    try expectEqual(@as(u8, 0), try parseTimeDigits("00", 0, 99));
+    try expectEqual(@as(u8, 99), try parseTimeDigits("99", 0, 99));
+    try expectEqual(@as(u8, 42), try parseTimeDigits("42", 0, 99));
+
+    const expectError = std.testing.expectError;
+    try expectError(error.CertificateTimeInvalid, parseTimeDigits("13", 1, 12));
+    try expectError(error.CertificateTimeInvalid, parseTimeDigits("00", 1, 12));
+    try expectError(error.CertificateTimeInvalid, parseTimeDigits("Di", 0, 99));
+}
+
+pub fn parseYear4(text: *const [4]u8) !u16 {
+    const result = if (use_vectors) result: {
+        const nnnn: @Vector(4, u32) = .{ text[0], text[1], text[2], text[3] };
+        const zero: @Vector(4, u32) = .{ '0', '0', '0', '0' };
+        const mmmm: @Vector(4, u32) = .{ 1000, 100, 10, 1 };
+        break :result @reduce(.Add, (nnnn -% zero) *% mmmm);
+    } else std.fmt.parseInt(u16, text, 10) catch return error.CertificateTimeInvalid;
+    if (result > 9999) return error.CertificateTimeInvalid;
+    return @truncate(result);
+}
+
+test parseYear4 {
+    const expectEqual = std.testing.expectEqual;
+    try expectEqual(@as(u16, 0), try parseYear4("0000"));
+    try expectEqual(@as(u16, 9999), try parseYear4("9999"));
+    try expectEqual(@as(u16, 1988), try parseYear4("1988"));
+
+    const expectError = std.testing.expectError;
+    try expectError(error.CertificateTimeInvalid, parseYear4("999b"));
+    try expectError(error.CertificateTimeInvalid, parseYear4("crap"));
+    try expectError(error.CertificateTimeInvalid, parseYear4("r:bQ"));
+}
+
+pub fn parseAlgorithm(bytes: []const u8, element: der.Element) ParseEnumError!Algorithm {
+    return parseEnum(Algorithm, bytes, element);
+}
+
+pub fn parseAlgorithmCategory(bytes: []const u8, element: der.Element) ParseEnumError!AlgorithmCategory {
+    return parseEnum(AlgorithmCategory, bytes, element);
+}
+
+pub fn parseAttribute(bytes: []const u8, element: der.Element) ParseEnumError!Attribute {
+    return parseEnum(Attribute, bytes, element);
+}
+
+pub fn parseNamedCurve(bytes: []const u8, element: der.Element) ParseEnumError!NamedCurve {
+    return parseEnum(NamedCurve, bytes, element);
+}
+
+pub fn parseExtensionId(bytes: []const u8, element: der.Element) ParseEnumError!ExtensionId {
+    return parseEnum(ExtensionId, bytes, element);
+}
+
+pub const ParseEnumError = error{ CertificateFieldHasWrongDataType, CertificateHasUnrecognizedObjectId };
+
+fn parseEnum(comptime E: type, bytes: []const u8, element: der.Element) ParseEnumError!E {
+    if (element.identifier.tag != .object_identifier)
+        return error.CertificateFieldHasWrongDataType;
+    const oid_bytes = bytes[element.slice.start..element.slice.end];
+    return E.map.get(oid_bytes) orelse return error.CertificateHasUnrecognizedObjectId;
+}
+
+pub const ParseVersionError = error{ UnsupportedCertificateVersion, CertificateFieldHasInvalidLength };
+
+pub fn parseVersion(bytes: []const u8, version_elem: der.Element) ParseVersionError!Version {
+    if (@as(u8, @bitCast(version_elem.identifier)) != 0xa0)
+        return .v1;
+
+    if (version_elem.slice.end - version_elem.slice.start != 3)
+        return error.CertificateFieldHasInvalidLength;
+
+    const encoded_version = bytes[version_elem.slice.start..version_elem.slice.end];
+
+    if (mem.eql(u8, encoded_version, "\x02\x01\x02")) {
+        return .v3;
+    } else if (mem.eql(u8, encoded_version, "\x02\x01\x01")) {
+        return .v2;
+    } else if (mem.eql(u8, encoded_version, "\x02\x01\x00")) {
+        return .v1;
+    }
+
+    return error.UnsupportedCertificateVersion;
+}
+
+pub fn verifyRsa(
+    comptime Hash: type,
+    message: []const u8,
+    sig: []const u8,
+    pub_key_algo: Parsed.PubKeyAlgo,
+    pub_key: []const u8,
+) !void {
+    if (pub_key_algo != .rsaEncryption) return error.CertificateSignatureAlgorithmMismatch;
+    const pk_components = try rsa.PublicKey.parseDer(pub_key);
+    const exponent = pk_components.exponent;
+    const modulus = pk_components.modulus;
+    if (exponent.len > modulus.len) return error.CertificatePublicKeyInvalid;
+    if (sig.len != modulus.len) return error.CertificateSignatureInvalidLength;
+
+    const hash_der = switch (Hash) {
+        crypto.hash.Sha1 => [_]u8{
+            0x30, 0x21, 0x30, 0x09, 0x06, 0x05, 0x2b, 0x0e,
+            0x03, 0x02, 0x1a, 0x05, 0x00, 0x04, 0x14,
+        },
+        crypto.hash.sha2.Sha224 => [_]u8{
+            0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+            0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x04, 0x05,
+            0x00, 0x04, 0x1c,
+        },
+        crypto.hash.sha2.Sha256 => [_]u8{
+            0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+            0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05,
+            0x00, 0x04, 0x20,
+        },
+        crypto.hash.sha2.Sha384 => [_]u8{
+            0x30, 0x41, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+            0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x02, 0x05,
+            0x00, 0x04, 0x30,
+        },
+        crypto.hash.sha2.Sha512 => [_]u8{
+            0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+            0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,
+            0x00, 0x04, 0x40,
+        },
+        else => @compileError("unreachable"),
+    };
+
+    var msg_hashed: [Hash.digest_length]u8 = undefined;
+    Hash.hash(message, &msg_hashed, .{});
+
+    switch (modulus.len) {
+        inline 128, 256, 384, 512 => |modulus_len| {
+            const ps_len = modulus_len - (hash_der.len + msg_hashed.len) - 3;
+            const em: [modulus_len]u8 =
+                [2]u8{ 0, 1 } ++
+                ([1]u8{0xff} ** ps_len) ++
+                [1]u8{0} ++
+                hash_der ++
+                msg_hashed;
+
+            const public_key = rsa.PublicKey.fromBytes(exponent, modulus) catch return error.CertificateSignatureInvalid;
+            const em_dec = rsa.encrypt(modulus_len, sig[0..modulus_len].*, public_key) catch |err| switch (err) {
+                error.MessageTooLong => unreachable,
+            };
+
+            if (!mem.eql(u8, &em, &em_dec)) {
+                return error.CertificateSignatureInvalid;
+            }
+        },
+        else => {
+            return error.CertificateSignatureUnsupportedBitCount;
+        },
+    }
+}
+
+pub fn encryptPKCS1(
+    out: []u8,
+    message: []u8,
+    pub_key: []const u8,
+) ![]u8 {
+    const pk_components = try rsa.PublicKey.parseDer(pub_key);
+    const exponent = pk_components.exponent;
+    const modulus = pk_components.modulus;
+    std.debug.assert(modulus.len > message.len + 11);
+
+    switch (modulus.len) {
+        inline 128, 256, 384, 512 => |modulus_len| {
+            const ps_len = modulus_len - message.len - 3;
+            var em: [modulus_len]u8 = undefined;
+            em[0] = 0;
+            em[1] = 2;
+            const ps = em[2..][0..ps_len];
+            em[ps_len + 2] = 0;
+            @memcpy(em[modulus_len - message.len .. modulus_len], message);
+            while (true) {
+                crypto.random.bytes(ps);
+                if (std.mem.indexOfScalar(u8, ps, 0) == null) break;
+            }
+
+            const public_key = rsa.PublicKey.fromBytes(exponent, modulus) catch return error.CertificateSignatureInvalid;
+            @memcpy(out[0..modulus_len], &try rsa.encrypt(modulus_len, em, public_key));
+            return out[0..modulus_len];
+        },
+        else => {
+            std.debug.print("{}", .{modulus.len});
+            return error.CertificateSignatureUnsupportedBitCount;
+        },
+    }
+}
+
+fn verify_ecdsa(
+    comptime Hash: type,
+    message: []const u8,
+    encoded_sig: []const u8,
+    pub_key_algo: Parsed.PubKeyAlgo,
+    sec1_pub_key: []const u8,
+) !void {
+    const sig_named_curve = switch (pub_key_algo) {
+        .X9_62_id_ecPublicKey => |named_curve| named_curve,
+        else => return error.CertificateSignatureAlgorithmMismatch,
+    };
+
+    switch (sig_named_curve) {
+        .secp521r1 => {
+            return error.CertificateSignatureNamedCurveUnsupported;
+        },
+        inline .X9_62_prime256v1,
+        .secp384r1,
+        => |curve| {
+            const Ecdsa = crypto.sign.ecdsa.Ecdsa(curve.Curve(), Hash);
+            const sig = Ecdsa.Signature.fromDer(encoded_sig) catch |err| switch (err) {
+                error.InvalidEncoding => return error.CertificateSignatureInvalid,
+            };
+            const pub_key = Ecdsa.PublicKey.fromSec1(sec1_pub_key) catch |err| switch (err) {
+                error.InvalidEncoding => return error.CertificateSignatureInvalid,
+                error.NonCanonical => return error.CertificateSignatureInvalid,
+                error.NotSquare => return error.CertificateSignatureInvalid,
+            };
+            sig.verify(message, pub_key) catch |err| switch (err) {
+                error.IdentityElement => return error.CertificateSignatureInvalid,
+                error.NonCanonical => return error.CertificateSignatureInvalid,
+                error.SignatureVerificationFailed => return error.CertificateSignatureInvalid,
+            };
+        },
+    }
+}
+
+const crypto = std.crypto;
+const mem = std.mem;
+const Certificate = @This();
+
+pub const der = struct {
+    pub const Class = enum(u2) {
+        universal,
+        application,
+        context_specific,
+        private,
+    };
+
+    pub const PC = enum(u1) {
+        primitive,
+        constructed,
+    };
+
+    pub const Identifier = packed struct(u8) {
+        tag: Tag,
+        pc: PC,
+        class: Class,
+    };
+
+    pub const Tag = enum(u5) {
+        boolean = 1,
+        integer = 2,
+        bitstring = 3,
+        octetstring = 4,
+        null = 5,
+        object_identifier = 6,
+        sequence = 16,
+        sequence_of = 17,
+        utc_time = 23,
+        generalized_time = 24,
+        _,
+    };
+
+    pub const Element = struct {
+        identifier: Identifier,
+        slice: Slice,
+
+        pub const Slice = struct {
+            start: u32,
+            end: u32,
+
+            pub const empty: Slice = .{ .start = 0, .end = 0 };
+        };
+
+        pub const ParseElementError = error{CertificateFieldHasInvalidLength};
+
+        pub fn parse(bytes: []const u8, index: u32) ParseElementError!Element {
+            var i = index;
+            const identifier = @as(Identifier, @bitCast(bytes[i]));
+            i += 1;
+            const size_byte = bytes[i];
+            i += 1;
+            if ((size_byte >> 7) == 0) {
+                return .{
+                    .identifier = identifier,
+                    .slice = .{
+                        .start = i,
+                        .end = i + size_byte,
+                    },
+                };
+            }
+
+            const len_size = @as(u7, @truncate(size_byte));
+            if (len_size > @sizeOf(u32)) {
+                return error.CertificateFieldHasInvalidLength;
+            }
+
+            const end_i = i + len_size;
+            var long_form_size: u32 = 0;
+            while (i < end_i) : (i += 1) {
+                long_form_size = (long_form_size << 8) | bytes[i];
+            }
+
+            return .{
+                .identifier = identifier,
+                .slice = .{
+                    .start = i,
+                    .end = i + long_form_size,
+                },
+            };
+        }
+    };
+};
+
+test {
+    _ = Bundle;
+}
+
+pub const rsa = struct {
+    const max_modulus_bits = 4096;
+    const Uint = std.crypto.ff.Uint(max_modulus_bits);
+    const Modulus = std.crypto.ff.Modulus(max_modulus_bits);
+    const Fe = Modulus.Fe;
+
+    pub const PSSSignature = struct {
+        pub fn fromBytes(comptime modulus_len: usize, msg: []const u8) [modulus_len]u8 {
+            var result = [1]u8{0} ** modulus_len;
+            std.mem.copyForwards(u8, &result, msg);
+            return result;
+        }
+
+        pub fn verify(comptime modulus_len: usize, sig: [modulus_len]u8, msg: []const u8, public_key: PublicKey, comptime Hash: type) !void {
+            const mod_bits = public_key.n.bits();
+            const em_dec = try encrypt(modulus_len, sig, public_key);
+
+            EMSA_PSS_VERIFY(msg, &em_dec, mod_bits - 1, Hash.digest_length, Hash) catch unreachable;
+        }
+
+        fn EMSA_PSS_VERIFY(msg: []const u8, em: []const u8, emBit: usize, sLen: usize, comptime Hash: type) !void {
+            // 1.   If the length of M is greater than the input limitation for
+            //      the hash function (2^61 - 1 octets for SHA-1), output
+            //      "inconsistent" and stop.
+            // All the cryptographic hash functions in the standard library have a limit of >= 2^61 - 1.
+            // Even then, this check is only there for paranoia. In the context of TLS certifcates, emBit cannot exceed 4096.
+            if (emBit >= 1 << 61) return error.InvalidSignature;
+
+            // emLen = \ceil(emBits/8)
+            const emLen = ((emBit - 1) / 8) + 1;
+            std.debug.assert(emLen == em.len);
+
+            // 2.   Let mHash = Hash(M), an octet string of length hLen.
+            var mHash: [Hash.digest_length]u8 = undefined;
+            Hash.hash(msg, &mHash, .{});
+
+            // 3.   If emLen < hLen + sLen + 2, output "inconsistent" and stop.
+            if (emLen < Hash.digest_length + sLen + 2) {
+                return error.InvalidSignature;
+            }
+
+            // 4.   If the rightmost octet of EM does not have hexadecimal value
+            //      0xbc, output "inconsistent" and stop.
+            if (em[em.len - 1] != 0xbc) {
+                return error.InvalidSignature;
+            }
+
+            // 5.   Let maskedDB be the leftmost emLen - hLen - 1 octets of EM,
+            //      and let H be the next hLen octets.
+            const maskedDB = em[0..(emLen - Hash.digest_length - 1)];
+            const h = em[(emLen - Hash.digest_length - 1)..(emLen - 1)][0..Hash.digest_length];
+
+            // 6.   If the leftmost 8emLen - emBits bits of the leftmost octet in
+            //      maskedDB are not all equal to zero, output "inconsistent" and
+            //      stop.
+            const zero_bits = emLen * 8 - emBit;
+            var mask: u8 = maskedDB[0];
+            var i: usize = 0;
+            while (i < 8 - zero_bits) : (i += 1) {
+                mask = mask >> 1;
+            }
+            if (mask != 0) {
+                return error.InvalidSignature;
+            }
+
+            // 7.   Let dbMask = MGF(H, emLen - hLen - 1).
+            const mgf_len = emLen - Hash.digest_length - 1;
+            var mgf_out_buf: [512]u8 = undefined;
+            if (mgf_len > mgf_out_buf.len) { // Modulus > 4096 bits
+                return error.InvalidSignature;
+            }
+            const mgf_out = mgf_out_buf[0 .. ((mgf_len - 1) / Hash.digest_length + 1) * Hash.digest_length];
+            var dbMask = try MGF1(Hash, mgf_out, h, mgf_len);
+
+            // 8.   Let DB = maskedDB \xor dbMask.
+            i = 0;
+            while (i < dbMask.len) : (i += 1) {
+                dbMask[i] = maskedDB[i] ^ dbMask[i];
+            }
+
+            // 9.   Set the leftmost 8emLen - emBits bits of the leftmost octet
+            //      in DB to zero.
+            i = 0;
+            mask = 0;
+            while (i < 8 - zero_bits) : (i += 1) {
+                mask = mask << 1;
+                mask += 1;
+            }
+            dbMask[0] = dbMask[0] & mask;
+
+            // 10.  If the emLen - hLen - sLen - 2 leftmost octets of DB are not
+            //      zero or if the octet at position emLen - hLen - sLen - 1 (the
+            //      leftmost position is "position 1") does not have hexadecimal
+            //      value 0x01, output "inconsistent" and stop.
+            if (dbMask[mgf_len - sLen - 2] != 0x00) {
+                return error.InvalidSignature;
+            }
+
+            if (dbMask[mgf_len - sLen - 1] != 0x01) {
+                return error.InvalidSignature;
+            }
+
+            // 11.  Let salt be the last sLen octets of DB.
+            const salt = dbMask[(mgf_len - sLen)..];
+
+            // 12.  Let
+            //         M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt ;
+            //      M' is an octet string of length 8 + hLen + sLen with eight
+            //      initial zero octets.
+            if (sLen > Hash.digest_length) { // A seed larger than the hash length would be useless
+                return error.InvalidSignature;
+            }
+            var m_p_buf: [8 + Hash.digest_length + Hash.digest_length]u8 = undefined;
+            var m_p = m_p_buf[0 .. 8 + Hash.digest_length + sLen];
+            std.mem.copyForwards(u8, m_p, &([_]u8{0} ** 8));
+            std.mem.copyForwards(u8, m_p[8..], &mHash);
+            std.mem.copyForwards(u8, m_p[(8 + Hash.digest_length)..], salt);
+
+            // 13.  Let H' = Hash(M'), an octet string of length hLen.
+            var h_p: [Hash.digest_length]u8 = undefined;
+            Hash.hash(m_p, &h_p, .{});
+
+            // 14.  If H = H', output "consistent".  Otherwise, output
+            //      "inconsistent".
+            if (!std.mem.eql(u8, h, &h_p)) {
+                return error.InvalidSignature;
+            }
+        }
+
+        fn MGF1(comptime Hash: type, out: []u8, seed: *const [Hash.digest_length]u8, len: usize) ![]u8 {
+            var counter: usize = 0;
+            var idx: usize = 0;
+            var c: [4]u8 = undefined;
+            var hash: [Hash.digest_length + c.len]u8 = undefined;
+            @memcpy(hash[0..Hash.digest_length], seed);
+            var hashed: [Hash.digest_length]u8 = undefined;
+
+            while (idx < len) {
+                c[0] = @as(u8, @intCast((counter >> 24) & 0xFF));
+                c[1] = @as(u8, @intCast((counter >> 16) & 0xFF));
+                c[2] = @as(u8, @intCast((counter >> 8) & 0xFF));
+                c[3] = @as(u8, @intCast(counter & 0xFF));
+
+                std.mem.copyForwards(u8, hash[seed.len..], &c);
+                Hash.hash(&hash, &hashed, .{});
+
+                std.mem.copyForwards(u8, out[idx..], &hashed);
+                idx += hashed.len;
+
+                counter += 1;
+            }
+
+            return out[0..len];
+        }
+    };
+
+    pub const PublicKey = struct {
+        n: Modulus,
+        e: Fe,
+
+        pub fn fromBytes(pub_bytes: []const u8, modulus_bytes: []const u8) !PublicKey {
+            // Reject modulus below 512 bits.
+            // 512-bit RSA was factored in 1999, so this limit barely means anything,
+            // but establish some limit now to ratchet in what we can.
+            const _n = Modulus.fromBytes(modulus_bytes, .big) catch return error.CertificatePublicKeyInvalid;
+            if (_n.bits() < 512) return error.CertificatePublicKeyInvalid;
+
+            // Exponent must be odd and greater than 2.
+            // Also, it must be less than 2^32 to mitigate DoS attacks.
+            // Windows CryptoAPI doesn't support values larger than 32 bits [1], so it is
+            // unlikely that exponents larger than 32 bits are being used for anything
+            // Windows commonly does.
+            // [1] https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-rsapubkey
+            if (pub_bytes.len > 4) return error.CertificatePublicKeyInvalid;
+            const _e = Fe.fromBytes(_n, pub_bytes, .big) catch return error.CertificatePublicKeyInvalid;
+            if (!_e.isOdd()) return error.CertificatePublicKeyInvalid;
+            const e_v = _e.toPrimitive(u32) catch return error.CertificatePublicKeyInvalid;
+            if (e_v < 2) return error.CertificatePublicKeyInvalid;
+
+            return .{
+                .n = _n,
+                .e = _e,
+            };
+        }
+
+        pub fn parseDer(pub_key: []const u8) !struct { modulus: []const u8, exponent: []const u8 } {
+            const pub_key_seq = try der.Element.parse(pub_key, 0);
+            if (pub_key_seq.identifier.tag != .sequence) return error.CertificateFieldHasWrongDataType;
+            const modulus_elem = try der.Element.parse(pub_key, pub_key_seq.slice.start);
+            if (modulus_elem.identifier.tag != .integer) return error.CertificateFieldHasWrongDataType;
+            const exponent_elem = try der.Element.parse(pub_key, modulus_elem.slice.end);
+            if (exponent_elem.identifier.tag != .integer) return error.CertificateFieldHasWrongDataType;
+            // Skip over meaningless zeroes in the modulus.
+            const modulus_raw = pub_key[modulus_elem.slice.start..modulus_elem.slice.end];
+            const modulus_offset = for (modulus_raw, 0..) |byte, i| {
+                if (byte != 0) break i;
+            } else modulus_raw.len;
+            return .{
+                .modulus = modulus_raw[modulus_offset..],
+                .exponent = pub_key[exponent_elem.slice.start..exponent_elem.slice.end],
+            };
+        }
+    };
+
+    fn encrypt(comptime modulus_len: usize, msg: [modulus_len]u8, public_key: PublicKey) ![modulus_len]u8 {
+        const m = Fe.fromBytes(public_key.n, &msg, .big) catch return error.MessageTooLong;
+        const e = public_key.n.powPublic(m, public_key.e) catch unreachable;
+        var res: [modulus_len]u8 = undefined;
+        e.toBytes(&res, .big) catch unreachable;
+        return res;
+    }
+};
+
+const use_vectors = @import("builtin").zig_backend != .stage2_x86_64;

--- a/src/reader.zig
+++ b/src/reader.zig
@@ -23,8 +23,8 @@ pub fn Reader(comptime S: type) type {
 
         pub fn init(stream: S, timeout: i32) !Self {
             const timeval = &std.mem.toBytes(std.posix.timeval{
-                .sec = @intCast(@divTrunc(timeout, 1000)),
-                .usec = @intCast(@mod(timeout, 1000) * 1000),
+                .tv_sec = @intCast(@divTrunc(timeout, 1000)),
+                .tv_usec = @intCast(@mod(timeout, 1000) * 1000),
             });
             try stream.readTimeout(timeval);
 

--- a/src/smtp.zig
+++ b/src/smtp.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
+const Bundle = @import( "crypto/Bundle.zig" );
 
 const Allocator = std.mem.Allocator;
-const Bundle = std.crypto.Certificate.Bundle;
 
 pub const client = @import("client.zig");
 pub const Client = client.Client(Stream);

--- a/src/stream.zig
+++ b/src/stream.zig
@@ -3,11 +3,13 @@ const lib = @import("lib.zig");
 
 const net = std.net;
 const posix = std.posix;
-const tls = std.crypto.tls;
+const tls = struct {
+  const Client = @import( "tlsclient.zig" );
+};
 
 const Config = lib.Config;
 const Allocator = std.mem.Allocator;
-const Bundle = std.crypto.Certificate.Bundle;
+const Bundle = @import( "crypto/Bundle.zig" );
 
 pub const Stream = struct {
     // not null if we own ca_bundle
@@ -30,7 +32,7 @@ pub const Stream = struct {
 
     pub fn deinit(self: *Stream) void {
         if (self.tls_client) |*tls_client| {
-            _ = tls_client.writeEnd(self.stream, "", true) catch {};
+            _ = tls_client.writeEnd(self.stream, "", true, .alert) catch {};
         }
         if (self.ca_bundle) |*ca_bundle| {
             ca_bundle.deinit(self.allocator.?);

--- a/src/tlsclient.zig
+++ b/src/tlsclient.zig
@@ -1,0 +1,1387 @@
+const std = @import("std");
+const tls = std.crypto.tls;
+const Client = @This();
+const net = std.net;
+const mem = std.mem;
+const crypto = std.crypto;
+const assert = std.debug.assert;
+const Certificate = @import("crypto/Certificate.zig");
+
+const max_cleartext_len = 1 << 14;
+const max_ciphertext_len = max_cleartext_len + 1024;
+const int2 = tls.int2;
+const int3 = tls.int3;
+const array = tls.array;
+const enum_array = tls.enum_array;
+
+read_seq: u64,
+write_seq: u64,
+/// When this is true, the stream may still not be at the end because there
+/// may be data in `partially_read_buffer`.
+received_close_notify: bool,
+/// By default, reaching the end-of-stream when reading from the server will
+/// cause `error.TlsConnectionTruncated` to be returned, unless a close_notify
+/// message has been received. By setting this flag to `true`, instead, the
+/// end-of-stream will be forwarded to the application layer above TLS.
+/// This makes the application vulnerable to truncation attacks unless the
+/// application layer itself verifies that the amount of data received equals
+/// the amount of data expected, such as HTTP with the Content-Length header.
+allow_truncation_attacks: bool = false,
+/// RFC 5746
+secure_renegotiation: bool = false,
+cipher: ?ApplicationCipher,
+/// The size is enough to contain exactly one TLSCiphertext record.
+/// This buffer is indexed by `cleartext_slice` and `ciphertext_slice`,
+/// where `cleartext_slice` must preceed `ciphertext_slice`.
+/// Note that this is a little bit off from `std.crypto.tls.Client`, which
+/// requires `cleartext_slice.ptr + cleartext_slice.len == ciphertext.ptr`.
+partially_read_buffer: [tls.max_ciphertext_record_len]u8,
+/// Slice into `partially_read_buffer` which is cleartext
+cleartext_slice: []u8,
+/// Slice into `partially_read_buffer` which is ciphertext
+ciphertext_slice: []u8,
+
+/// `std.net.Stream` conforms to `std.crypto.tls.Client.StreamInterface`
+pub const StreamInterface = std.crypto.tls.Client.StreamInterface;
+
+pub fn makeClientHello(buf: []u8, host: []const u8, client_random: [32]u8) []const u8 {
+    const host_len: u16 = @intCast(host.len);
+    const extensions_payload =
+        extension(.supported_versions, [_]u8{
+        0x02, // byte length of supported versions
+        0x03, 0x03, // TLS 1.2
+    }) ++ extension(.signature_algorithms, enum_array(tls.SignatureScheme, &.{
+        .ecdsa_secp256r1_sha256,
+        .ecdsa_secp384r1_sha384,
+        .rsa_pss_rsae_sha256,
+        .rsa_pss_rsae_sha384,
+        .rsa_pss_rsae_sha512,
+        .rsa_pkcs1_sha256,
+        .rsa_pkcs1_sha384,
+        .rsa_pkcs1_sha512,
+    })) ++ extension(.supported_groups, enum_array(tls.NamedGroup, &.{
+        .secp256r1,
+        .x25519,
+    })) ++ extension(.ec_point_formats, [2]u8{
+        1, // number of formats
+        @intFromEnum(ECPointFormat.uncompressed),
+    }) ++
+        extension(.extended_master_secret, [0]u8{}) ++
+        // no renegotiation data
+        extension(.renegotiation_info, [1]u8{0}) ++
+        int2(@intFromEnum(ExtensionType.server_name)) ++
+        int2(host_len + 5) ++ // byte length of this extension payload
+        int2(host_len + 3) ++ // server_name_list byte count
+        [1]u8{0x00} ++ // name_type
+        int2(host_len);
+
+    const extensions_header =
+        int2(@intCast(extensions_payload.len + host_len)) ++
+        extensions_payload;
+
+    const legacy_compression_methods = 0x0100;
+
+    const client_hello =
+        int2(@intFromEnum(tls.ProtocolVersion.tls_1_2)) ++
+        client_random ++
+        [1]u8{0} ++ // session_id
+        cipher_suites ++
+        int2(legacy_compression_methods) ++
+        extensions_header;
+
+    const out_handshake =
+        [_]u8{@intFromEnum(tls.HandshakeType.client_hello)} ++
+        int3(@intCast(client_hello.len + host_len)) ++
+        client_hello;
+
+    const plaintext_header = [_]u8{
+        @intFromEnum(tls.ContentType.handshake),
+        0x03, 0x01, // legacy_record_version
+    } ++ int2(@intCast(out_handshake.len + host_len)) ++ out_handshake;
+
+    @memcpy(buf[0..plaintext_header.len], &plaintext_header);
+    return buf[0..plaintext_header.len];
+}
+
+/// Initiates a TLS handshake and establishes a TLSv1.2 session with `stream`.
+///
+/// `host` is only borrowed during this function call.
+pub fn init(stream: std.net.Stream, ca_bundle: Certificate.Bundle, host: []const u8) !Client {
+    var random_buffer: [72]u8 = undefined;
+    crypto.random.bytes(&random_buffer);
+    const client_random = random_buffer[0..32].*;
+    const keypair_seed = random_buffer[32..64].*;
+    const explicit_iv_random = random_buffer[64..72].*;
+
+    var hash: MessageHashType = undefined;
+    var next_cipher: ApplicationCipher = undefined;
+
+    var c: Client = .{
+        .read_seq = 0,
+        .write_seq = 0,
+        .ciphertext_slice = undefined,
+        .cleartext_slice = undefined,
+        .received_close_notify = false,
+        .cipher = null,
+        .partially_read_buffer = undefined,
+    };
+    c.ciphertext_slice = c.partially_read_buffer[0..0];
+    c.cleartext_slice = c.partially_read_buffer[0..0];
+    const client_stream = ClientAndStream{ .c = &c, .s = stream };
+
+    // 256 is enough for TLS 1.2
+    var buf: [256]u8 = undefined;
+    const plaintext_header = makeClientHello(&buf, host, client_random);
+
+    {
+        var iovecs = [_]std.posix.iovec_const{
+            .{ .base = plaintext_header.ptr, .len = plaintext_header.len },
+            .{ .base = host.ptr, .len = host.len },
+        };
+        try stream.writevAll(&iovecs);
+    }
+
+    const client_hello_bytes1 = plaintext_header[5..];
+    var server_random: [32]u8 = undefined;
+    var extended_master_secret: bool = false;
+
+    // In theory the certificate could be as long as 16MB though.
+    var handshake_buffer: [16000]u8 = undefined;
+    var cipher_suite_tag: CipherSuite = undefined;
+    var d: tls.Decoder = .{ .buf = &handshake_buffer };
+    {
+        try d.readAtLeastOurAmt(client_stream, 4);
+        const handshake_type = d.decode(tls.HandshakeType);
+        if (handshake_type != .server_hello) return error.TlsUnexpectedMessage;
+        const length = d.decode(u24);
+        try d.readAtLeast(client_stream, length);
+        const server_hello_fragment = d.buf[d.idx - 4 ..][0 .. length + 4];
+        var hsd = try d.sub(length);
+        try hsd.ensure(2 + 32);
+        const legacy_version = hsd.decode(u16);
+        _ = legacy_version;
+        server_random = hsd.array(32).*;
+        try hsd.ensure(1);
+        const legacy_session_id_echo_len = hsd.decode(u8);
+        try hsd.ensure(legacy_session_id_echo_len);
+        const legacy_session_id_echo = hsd.slice(legacy_session_id_echo_len);
+        _ = legacy_session_id_echo;
+        try hsd.ensure(2 + 1);
+        cipher_suite_tag = hsd.decode(CipherSuite);
+        const hash_tag = messageHash(getAEAD(cipher_suite_tag));
+        hash = switch (hash_tag) {
+            .sha256 => MessageHashType{ .sha256 = crypto.hash.sha2.Sha256.init(.{}) },
+            .sha384 => MessageHashType{ .sha384 = crypto.hash.sha2.Sha384.init(.{}) },
+        };
+        next_cipher = switch (getAEAD(cipher_suite_tag)) {
+            inline .AES_128_GCM_SHA256,
+            .AES_256_GCM_SHA384,
+            .CHACHA20_POLY1305_SHA256,
+            => |tag| createApplicationCipher(tag),
+            else => unreachable,
+        };
+        switch (hash) {
+            inline else => |*h| {
+                h.update(client_hello_bytes1);
+                h.update(host);
+                h.update(server_hello_fragment);
+            },
+        }
+        hsd.skip(1); // legacy_compression_method
+        var extensions_size: u16 = 0;
+        if (!hsd.eof()) {
+            try hsd.ensure(2);
+            extensions_size = hsd.decode(u16);
+        }
+        var all_extd = try hsd.sub(extensions_size);
+        var supported_version: u16 = 0;
+        while (!all_extd.eof()) {
+            try all_extd.ensure(2 + 2);
+            const et = all_extd.decode(ExtensionType);
+            const ext_size = all_extd.decode(u16);
+            var extd = try all_extd.sub(ext_size);
+            switch (et) {
+                .supported_versions => {
+                    if (supported_version != 0) return error.TlsIllegalParameter;
+                    try extd.ensure(2);
+                    supported_version = extd.decode(u16);
+                },
+                .extended_master_secret => {
+                    extended_master_secret = true;
+                },
+                .renegotiation_info => {
+                    c.secure_renegotiation = true;
+                    if (ext_size != 1) return error.TlsHandshakeFailure;
+                    try extd.ensure(1);
+                    if (extd.decode(u8) != 0) return error.TlsHandshakeFailure;
+                },
+                else => {},
+            }
+        }
+    }
+
+    var main_cert_pub_key_algo: Certificate.AlgorithmCategory = undefined;
+    var main_cert_pub_key_buf: [600]u8 = undefined;
+    var main_cert_pub_key_len: u16 = undefined;
+
+    // Server Certificate
+    {
+        try d.readAtLeastOurAmt(client_stream, 4);
+        try d.ensure(4);
+        const handshake_type = d.decode(HandshakeType);
+        if (handshake_type != .certificate) return error.TlsUnexpectedMessage;
+        const length = d.decode(u24);
+
+        try d.readAtLeast(client_stream, length);
+        switch (hash) {
+            inline else => |*h| h.update(d.buf[d.idx - 4 ..][0 .. length + 4]),
+        }
+        var hsd = try d.sub(length);
+        try hsd.ensure(3);
+        const certs_size = hsd.decode(u24);
+        var certs_decoder = try hsd.sub(certs_size);
+
+        var cert_index: usize = 0;
+        var prev_cert: Certificate.Parsed = undefined;
+        const now_sec = std.time.timestamp();
+        while (!certs_decoder.eof()) {
+            try certs_decoder.ensure(3);
+            const cert_size = certs_decoder.decode(u24);
+            const certd = try certs_decoder.sub(cert_size);
+
+            const subject_cert: Certificate = .{
+                .buffer = certd.buf,
+                .index = @intCast(certd.idx),
+            };
+            const subject = try subject_cert.parse();
+
+            if (cert_index == 0) {
+                // Verify the host on the first certificate.
+                try subject.verifyHostName(host);
+
+                // Keep track of the public key for the
+                // certificate_verify message later.
+                main_cert_pub_key_algo = subject.pub_key_algo;
+                const pub_key = subject.pubKey();
+                if (pub_key.len > main_cert_pub_key_buf.len)
+                    return error.CertificatePublicKeyInvalid;
+                @memcpy(main_cert_pub_key_buf[0..pub_key.len], pub_key);
+                main_cert_pub_key_len = @intCast(pub_key.len);
+            } else {
+                try prev_cert.verify(subject, now_sec);
+            }
+
+            if (ca_bundle.verify(subject, now_sec)) |_| {
+                break;
+            } else |err| switch (err) {
+                error.CertificateIssuerNotFound => {},
+                else => |e| return e,
+            }
+
+            prev_cert = subject;
+            cert_index += 1;
+        } else return error.TlsAlertUnknownCa;
+    }
+
+    // Server Key Exchange Message
+    var shared_key_buf: [48]u8 = undefined;
+    var named_group: tls.NamedGroup = undefined;
+    // First 4 bytes are group type and length
+    var server_key_bytes: []const u8 = undefined;
+    const kea = getKeyExchangeAlgorithm(cipher_suite_tag);
+    if (kea != .RSA) {
+        try d.readAtLeastOurAmt(client_stream, 4);
+        try d.ensure(4);
+        const handshake_type = d.decode(HandshakeType);
+        if (handshake_type != .server_key_exchange) return error.TlsUnexpectedMessage;
+        const length = d.decode(u24);
+
+        try d.readAtLeast(client_stream, length);
+        switch (hash) {
+            inline else => |*h| h.update(d.buf[d.idx - 4 ..][0 .. length + 4]),
+        }
+        var hsd = try d.sub(length);
+
+        switch (kea) {
+            .ECDHE => {},
+            .RSA, .DHE => unreachable,
+        }
+        try hsd.ensure(4);
+        const curve_type = hsd.decode(ECCurveType);
+        if (curve_type != .named_curve) return error.TlsIllegalParameter;
+        named_group = hsd.decode(tls.NamedGroup);
+        const key_size = hsd.decode(u8);
+        try hsd.ensure(key_size);
+        server_key_bytes = hsd.buf[hsd.idx - 4 ..][0 .. 4 + key_size];
+        _ = hsd.slice(key_size);
+
+        // verify certificate
+        try hsd.ensure(4);
+        const scheme = hsd.decode(tls.SignatureScheme);
+        const sig_len = hsd.decode(u16);
+        try hsd.ensure(sig_len);
+        const encoded_sig = hsd.slice(sig_len);
+        const main_cert_pub_key = main_cert_pub_key_buf[0..main_cert_pub_key_len];
+        var verify_buf: [64 + 256]u8 = undefined;
+        // TODO: figure out an upper bound
+        assert(server_key_bytes.len < 256);
+        @memcpy(verify_buf[0..32], &client_random);
+        @memcpy(verify_buf[32..64], &server_random);
+        @memcpy(verify_buf[64 .. 64 + server_key_bytes.len], server_key_bytes);
+        const verify_bytes = verify_buf[0 .. 64 + server_key_bytes.len];
+
+        switch (scheme) {
+            inline .ecdsa_secp256r1_sha256,
+            .ecdsa_secp384r1_sha384,
+            => |comptime_scheme| {
+                if (main_cert_pub_key_algo != .X9_62_id_ecPublicKey)
+                    return error.TlsBadSignatureScheme;
+                const Ecdsa = SchemeEcdsa(comptime_scheme);
+                const sig = try Ecdsa.Signature.fromDer(encoded_sig);
+                const key = try Ecdsa.PublicKey.fromSec1(main_cert_pub_key);
+                try sig.verify(verify_bytes, key);
+            },
+            inline .rsa_pkcs1_sha1,
+            .rsa_pkcs1_sha256,
+            .rsa_pkcs1_sha384,
+            .rsa_pkcs1_sha512,
+            => |comptime_scheme| {
+                if (main_cert_pub_key_algo != .rsaEncryption) return error.TlsBadSignatureScheme;
+                const Hash = SchemeHash(comptime_scheme);
+                try Certificate.verifyRsa(
+                    Hash,
+                    verify_bytes,
+                    encoded_sig,
+                    .rsaEncryption,
+                    main_cert_pub_key,
+                );
+            },
+            inline .rsa_pss_rsae_sha256,
+            .rsa_pss_rsae_sha384,
+            .rsa_pss_rsae_sha512,
+            => |comptime_scheme| {
+                if (main_cert_pub_key_algo != .rsaEncryption) return error.TlsBadSignatureScheme;
+                const Hash = SchemeHash(comptime_scheme);
+                const rsa = Certificate.rsa;
+                const components = try rsa.PublicKey.parseDer(main_cert_pub_key);
+                const exponent = components.exponent;
+                const modulus = components.modulus;
+                switch (modulus.len) {
+                    inline 128, 256, 384, 512 => |modulus_len| {
+                        const key = try rsa.PublicKey.fromBytes(exponent, modulus);
+                        const sig = rsa.PSSSignature.fromBytes(modulus_len, encoded_sig);
+                        try rsa.PSSSignature.verify(modulus_len, sig, verify_bytes, key, Hash);
+                    },
+                    else => return error.TlsBadRsaSignatureBitCount,
+                }
+            },
+            else => return error.TlsBadSignatureScheme,
+        }
+    }
+
+    // Server Hello Done
+    {
+        try d.readAtLeastOurAmt(client_stream, 4);
+        try d.ensure(4);
+        const handshake_type = d.decode(HandshakeType);
+        if (handshake_type != .server_hello_done) return error.TlsUnexpectedMessage;
+        const length = d.decode(u24);
+
+        try d.readAtLeast(client_stream, length);
+        switch (hash) {
+            inline else => |*h| h.update(d.buf[d.idx - 4 ..][0 .. length + 4]),
+        }
+        if (length != 0) return error.TlsDecodeError;
+    }
+
+    // Client Key Exchange
+    var shared_key: []const u8 = undefined;
+    {
+        var public_key_buf: [512]u8 = undefined;
+        const public_key: []const u8 = switch (kea) {
+            .ECDHE => switch (named_group) {
+                .x25519 => blk: {
+                    const X25519 = crypto.dh.X25519;
+                    const ksl = X25519.public_length;
+                    if (server_key_bytes.len - 4 != ksl) return error.TlsIllegalParameter;
+
+                    const x25519_kp = X25519.KeyPair.create(keypair_seed) catch |err| switch (err) {
+                        // Only possible to happen if the private key is all zeroes.
+                        error.IdentityElement => return error.InsufficientEntropy,
+                    };
+
+                    shared_key = &(X25519.scalarmult(
+                        x25519_kp.secret_key,
+                        server_key_bytes[4 .. 4 + ksl].*,
+                    ) catch return error.TlsDecryptFailure);
+                    break :blk &x25519_kp.public_key;
+                },
+                .secp256r1 => blk: {
+                    const secp256r1 = crypto.sign.ecdsa.EcdsaP256Sha256;
+                    const pk = secp256r1.PublicKey.fromSec1(server_key_bytes[4..]) catch {
+                        return error.TlsDecryptFailure;
+                    };
+
+                    const secp256r1_kp = secp256r1.KeyPair.create(keypair_seed) catch |err| switch (err) {
+                        // Only possible to happen if the private key is all zeroes.
+                        error.IdentityElement => return error.InsufficientEntropy,
+                    };
+
+                    const mul = pk.p.mulPublic(secp256r1_kp.secret_key.bytes, .big) catch {
+                        return error.TlsDecryptFailure;
+                    };
+                    shared_key = &mul.affineCoordinates().x.toBytes(.big);
+                    break :blk &secp256r1_kp.public_key.toUncompressedSec1();
+                },
+                else => unreachable,
+            },
+            .RSA => blk: {
+                // 0x0303 for TLS 1.2
+                shared_key_buf[0] = 0x03;
+                shared_key_buf[1] = 0x03;
+                crypto.random.bytes(shared_key_buf[2..]);
+                shared_key = &shared_key_buf;
+                break :blk try Certificate.encryptPKCS1(&public_key_buf, &shared_key_buf, &main_cert_pub_key_buf);
+            },
+            .DHE => unreachable,
+        };
+        var record_header = [1]u8{@intFromEnum(tls.ContentType.handshake)} ++
+            tls.int2(@intFromEnum(tls.ProtocolVersion.tls_1_2)) ++
+            [2]u8{ undefined, undefined };
+        var header_buffer: [6]u8 = undefined;
+        header_buffer[0] = @intFromEnum(HandshakeType.client_key_exchange);
+        const header = switch (kea) {
+            .ECDHE => blk: {
+                record_header[3..5].* = int2(@intCast(public_key.len + 5));
+                header_buffer[1..4].* = int3(@intCast(public_key.len + 1));
+                header_buffer[4] = @intCast(public_key.len);
+                break :blk header_buffer[0..5];
+            },
+            .RSA => blk: {
+                record_header[3..5].* = int2(@intCast(public_key.len + 6));
+                header_buffer[1..4].* = int3(@intCast(public_key.len + 2));
+                header_buffer[4..6].* = int2(@intCast(public_key.len));
+                break :blk header_buffer[0..6];
+            },
+            .DHE => unreachable,
+        };
+        var iovecs = [_]std.posix.iovec_const{
+            .{ .base = &record_header, .len = record_header.len },
+            .{ .base = header.ptr, .len = header.len },
+            .{ .base = public_key.ptr, .len = public_key.len },
+        };
+        try stream.writevAll(&iovecs);
+        switch (hash) {
+            inline else => |*h| {
+                h.update(header);
+                h.update(public_key);
+            },
+        }
+    }
+
+    // Client Change Cipher Spec
+    {
+        const record = [1]u8{@intFromEnum(tls.ContentType.change_cipher_spec)} ++
+            tls.int2(@intFromEnum(tls.ProtocolVersion.tls_1_2)) ++
+            tls.int2(1) ++
+            [1]u8{1};
+        try stream.writeAll(&record);
+    }
+
+    // Calculate Keys
+    var master_secret: [48]u8 = undefined;
+    {
+        switch (hash) {
+            inline else => |h| if (extended_master_secret) {
+                master_secret = PRF(
+                    crypto.auth.hmac.Hmac(@TypeOf(h)),
+                    shared_key,
+                    "extended master secret",
+                    &h.peek(),
+                    48,
+                );
+            } else {
+                const seed = client_random ++ server_random;
+                master_secret = PRF(
+                    crypto.auth.hmac.Hmac(@TypeOf(h)),
+                    shared_key,
+                    "master secret",
+                    &seed,
+                    48,
+                );
+            },
+        }
+        // Key Expansion: note that AEAD do not need mac key
+        const seed2 = server_random ++ client_random;
+        switch (next_cipher) {
+            inline else => |*cipher| {
+                const Cipher = @TypeOf(cipher.*);
+                const AEAD = Cipher.AEAD;
+                const implicit_nonce_len = AEAD.nonce_length - Cipher.explicit_nonce_len;
+                const key_len = AEAD.key_length;
+                const total_len = 2 * (key_len + implicit_nonce_len);
+                const key_material = PRF(
+                    Cipher.Hmac,
+                    &master_secret,
+                    "key expansion",
+                    &seed2,
+                    total_len,
+                );
+                cipher.client_key = key_material[0..key_len].*;
+                cipher.server_key = key_material[key_len .. 2 * key_len].*;
+                const iv_material = key_material[2 * key_len ..];
+                cipher.client_iv[0..implicit_nonce_len].* = iv_material[0..implicit_nonce_len].*;
+                cipher.server_iv = iv_material[implicit_nonce_len .. 2 * implicit_nonce_len].* ++
+                    [1]u8{0} ** Cipher.explicit_nonce_len;
+                // RFC 9325, Section 7.2.1
+                // Use the sequency counter as GC, but also add some randomness to it
+                cipher.client_iv[implicit_nonce_len..].* = explicit_iv_random[0..Cipher.explicit_nonce_len].*;
+            },
+        }
+    }
+
+    c.cipher = next_cipher;
+
+    // Client Finished
+    {
+        const verify_data = switch (hash) {
+            inline else => |*h| PRF(
+                crypto.auth.hmac.Hmac(@TypeOf(h.*)),
+                &master_secret,
+                "client finished",
+                &h.peek(),
+                12,
+            ),
+        };
+        const handshake_finished: [16]u8 =
+            [1]u8{@intFromEnum(HandshakeType.finished)} ++
+            int3(12) ++ verify_data;
+        const total = try c.writeEnd(stream, &handshake_finished, false, .handshake);
+        assert(total == 16);
+        switch (hash) {
+            inline else => |*h| {
+                h.update(&handshake_finished);
+            },
+        }
+    }
+
+    c.cipher = null;
+
+    // Server Change Cipher Spec
+    {
+        try d.readAtLeastOurAmt(client_stream, 1);
+        if (d.decode(u8) != 1) return error.TlsUnexpectedMessage;
+    }
+
+    c.cipher = next_cipher;
+
+    // Server Finished
+    {
+        try d.readAtLeastOurAmt(client_stream, 4);
+        try d.ensure(4);
+        const handshake_type = d.decode(HandshakeType);
+        if (handshake_type != .finished) return error.TlsUnexpectedMessage;
+        const length = d.decode(u24);
+
+        try d.readAtLeast(client_stream, length);
+        if (length != 12) return error.TlsDecodeError;
+        try d.ensure(12);
+        const server_verify = d.array(12);
+        const verify_data = switch (hash) {
+            inline else => |*h| PRF(crypto.auth.hmac.Hmac(@TypeOf(h.*)), &master_secret, "server finished", &h.finalResult(), 12),
+        };
+        if (!mem.eql(u8, server_verify, &verify_data))
+            return error.TlsHandshakeFailure;
+    }
+
+    return c;
+}
+
+const ClientAndStream = struct {
+    c: *Client,
+    s: std.net.Stream,
+
+    pub fn readAtLeast(self: ClientAndStream, buffer: []u8, len: usize) !usize {
+        return self.c.readAtLeast(self.s, buffer, len);
+    }
+};
+
+/// Sends TLS-encrypted data to `stream`, which must conform to `StreamInterface`.
+/// Returns the number of plaintext bytes sent, which may be fewer than `bytes.len`.
+pub fn write(c: *Client, stream: std.net.Stream, bytes: []const u8) !usize {
+    return writeEnd(c, stream, bytes, false, .application_data);
+}
+
+/// Sends TLS-encrypted data to `stream`, which must conform to `StreamInterface`.
+pub fn writeAll(c: *Client, stream: std.net.Stream, bytes: []const u8) !void {
+    var index: usize = 0;
+    while (index < bytes.len) {
+        index += try c.write(stream, bytes[index..]);
+    }
+}
+
+/// Sends TLS-encrypted data to `stream`, which must conform to `StreamInterface`.
+/// If `end` is true, then this function additionally sends a `close_notify` alert,
+/// which is necessary for the server to distinguish between a properly finished
+/// TLS session, or a truncation attack.
+pub fn writeAllEnd(c: *Client, stream: std.net.Stream, bytes: []const u8, end: bool) !void {
+    var index: usize = 0;
+    while (index < bytes.len) {
+        index += try c.writeEnd(stream, bytes[index..], end, .application_data);
+    }
+}
+
+/// Sends TLS-encrypted data to `stream`, which must conform to `StreamInterface`.
+/// Returns the number of plaintext bytes sent, which may be fewer than `bytes.len`.
+/// If `end` is true, then this function additionally sends a `close_notify` alert,
+/// which is necessary for the server to distinguish between a properly finished
+/// TLS session, or a truncation attack.
+pub fn writeEnd(c: *Client, stream: std.net.Stream, bytes: []const u8, end: bool, inner_content_type: tls.ContentType) !usize {
+    var ciphertext_buf: [tls.max_ciphertext_record_len * 4]u8 = undefined;
+    var iovecs_buf: [6]std.posix.iovec_const = undefined;
+    var prepared = prepareCiphertextRecord(c, &iovecs_buf, &ciphertext_buf, bytes, inner_content_type);
+    if (end) {
+        prepared.iovec_end += prepareCiphertextRecord(
+            c,
+            iovecs_buf[prepared.iovec_end..],
+            ciphertext_buf[prepared.ciphertext_end..],
+            &tls.close_notify_alert,
+            .alert,
+        ).iovec_end;
+    }
+
+    const iovec_end = prepared.iovec_end;
+    const overhead_len = prepared.overhead_len;
+
+    // Ideally we would call writev exactly once here, however, we must ensure
+    // that we don't return with a record partially written.
+    var i: usize = 0;
+    var total_amt: usize = 0;
+    while (true) {
+        var amt = try stream.writev(iovecs_buf[i..iovec_end]);
+        while (amt >= iovecs_buf[i].len) {
+            const encrypted_amt = iovecs_buf[i].len;
+            total_amt += encrypted_amt - overhead_len;
+            amt -= encrypted_amt;
+            i += 1;
+            // Rely on the property that iovecs delineate records, meaning that
+            // if amt equals zero here, we have fortunately found ourselves
+            // with a short read that aligns at the record boundary.
+            if (i >= iovec_end) return total_amt;
+            // We also cannot return on a vector boundary if the final close_notify is
+            // not sent; otherwise the caller would not know to retry the call.
+            if (amt == 0 and (!end or i < iovec_end - 1)) return total_amt;
+        }
+        iovecs_buf[i].base += amt;
+        iovecs_buf[i].len -= amt;
+    }
+}
+
+const CiphertextRecordResult = struct {
+    iovec_end: usize,
+    ciphertext_end: usize,
+    /// How many bytes are taken up by overhead per record.
+    overhead_len: usize,
+};
+
+fn prepareCiphertextRecord(
+    c: *Client,
+    iovecs: []std.posix.iovec_const,
+    ciphertext_buf: []u8,
+    bytes: []const u8,
+    inner_content_type: tls.ContentType,
+) CiphertextRecordResult {
+    var ciphertext_end: usize = 0;
+    var iovec_end: usize = 0;
+    var bytes_i: usize = 0;
+    switch (c.cipher.?) {
+        inline else => |*p| {
+            const P = @TypeOf(p.*);
+            const V = @Vector(P.AEAD.nonce_length, u8);
+            const overhead_len = tls.record_header_len + P.explicit_nonce_len + P.AEAD.tag_length;
+            const close_notify_alert_reserved = tls.close_notify_alert.len + overhead_len;
+            while (true) {
+                const encrypted_content_len: u16 = @intCast(@min(
+                    @min(bytes.len - bytes_i, max_ciphertext_len),
+                    ciphertext_buf.len -| (close_notify_alert_reserved +
+                        overhead_len + ciphertext_end),
+                ));
+                if (encrypted_content_len == 0) return .{
+                    .iovec_end = iovec_end,
+                    .ciphertext_end = ciphertext_end,
+                    .overhead_len = overhead_len,
+                };
+
+                const cleartext = bytes[bytes_i..][0..encrypted_content_len];
+                bytes_i += encrypted_content_len;
+
+                const record_start = ciphertext_end;
+                const header = ciphertext_buf[ciphertext_end..][0..5];
+                // length including nonce, data and tag (and padding)
+                const full_length = P.explicit_nonce_len + encrypted_content_len + P.AEAD.tag_length;
+                header.* =
+                    [1]u8{@intFromEnum(inner_content_type)} ++
+                    int2(@intFromEnum(tls.ProtocolVersion.tls_1_2)) ++
+                    int2(@intCast(full_length));
+                ciphertext_end += header.len;
+                const explicit_nonce = ciphertext_buf[ciphertext_end..][0..P.explicit_nonce_len];
+                ciphertext_end += explicit_nonce.len;
+                const ciphertext = ciphertext_buf[ciphertext_end..][0..encrypted_content_len];
+                ciphertext_end += encrypted_content_len;
+                const auth_tag = ciphertext_buf[ciphertext_end..][0..P.AEAD.tag_length];
+                ciphertext_end += auth_tag.len;
+                // The nonce for AEAD is always 4+8 bytes, whether the explicit part is send or not
+                const pad = [1]u8{0} ** (P.AEAD.nonce_length - 8);
+                const seq_big = @as([8]u8, @bitCast(big(c.write_seq)));
+                const operand: V = pad ++ seq_big;
+                c.write_seq += 1; // TODO send key_update on overflow
+                const nonce = @as(V, p.client_iv) ^ operand;
+                explicit_nonce.* = @as([12]u8, nonce)[12 - P.explicit_nonce_len .. 12].*;
+                const ad = seq_big ++
+                    [1]u8{@intFromEnum(inner_content_type)} ++
+                    int2(@intFromEnum(tls.ProtocolVersion.tls_1_2)) ++
+                    int2(@intCast(encrypted_content_len));
+                P.AEAD.encrypt(ciphertext, auth_tag, cleartext, &ad, nonce, p.client_key);
+
+                const record = ciphertext_buf[record_start..ciphertext_end];
+                iovecs[iovec_end] = .{
+                    .base = record.ptr,
+                    .len = record.len,
+                };
+                iovec_end += 1;
+            }
+        },
+    }
+}
+
+pub fn eof(c: Client) bool {
+    return c.received_close_notify and
+        c.ciphertext_slice.len == 0 and
+        c.cleartext_slice.len == 0;
+}
+
+/// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.
+/// Returns the number of bytes read, calling the underlying read function the
+/// minimal number of times until the buffer has at least `len` bytes filled.
+/// If the number read is less than `len` it means the stream reached the end.
+/// Reaching the end of the stream is not an error condition.
+pub fn readAtLeast(c: *Client, stream: std.net.Stream, buffer: []u8, len: usize) !usize {
+    var iovecs = [1]std.posix.iovec{.{ .base = buffer.ptr, .len = buffer.len }};
+    return readvAtLeast(c, stream, &iovecs, len);
+}
+
+/// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.
+pub fn read(c: *Client, stream: std.net.Stream, buffer: []u8) !usize {
+    return readAtLeast(c, stream, buffer, 1);
+}
+
+/// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.
+/// Returns the number of bytes read. If the number read is smaller than
+/// `buffer.len`, it means the stream reached the end. Reaching the end of the
+/// stream is not an error condition.
+pub fn readAll(c: *Client, stream: std.net.Stream, buffer: []u8) !usize {
+    return readAtLeast(c, stream, buffer, buffer.len);
+}
+
+/// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.
+/// Returns the number of bytes read. If the number read is less than the space
+/// provided it means the stream reached the end. Reaching the end of the
+/// stream is not an error condition.
+/// The `iovecs` parameter is mutable because this function needs to mutate the fields in
+/// order to handle partial reads from the underlying stream layer.
+pub fn readv(c: *Client, stream: std.net.Stream, iovecs: []std.posix.iovec) !usize {
+    return readvAtLeast(c, stream, iovecs, 1);
+}
+
+/// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.
+/// Returns the number of bytes read, calling the underlying read function the
+/// minimal number of times until the iovecs have at least `len` bytes filled.
+/// If the number read is less than `len` it means the stream reached the end.
+/// Reaching the end of the stream is not an error condition.
+/// The `iovecs` parameter is mutable because this function needs to mutate the fields in
+/// order to handle partial reads from the underlying stream layer.
+pub fn readvAtLeast(c: *Client, stream: std.net.Stream, iovecs: []std.posix.iovec, len: usize) !usize {
+    if (c.eof()) return 0;
+
+    var off_i: usize = 0;
+    var vec_i: usize = 0;
+    while (true) {
+        var amt = try c.readvAdvanced(stream, iovecs[vec_i..]);
+        off_i += amt;
+        if (c.eof() or off_i >= len) return off_i;
+        while (amt >= iovecs[vec_i].len) {
+            amt -= iovecs[vec_i].len;
+            vec_i += 1;
+        }
+        iovecs[vec_i].base += amt;
+        iovecs[vec_i].len -= amt;
+    }
+}
+
+/// Receives TLS-encrypted data from `stream`, which must conform to `StreamInterface`.
+/// Returns number of bytes that have been read, populated inside `iovecs`. A
+/// return value of zero bytes does not mean end of stream. Instead, check the `eof()`
+/// for the end of stream. The `eof()` may be true after any call to
+/// `read`, including when greater than zero bytes are returned, and this
+/// function asserts that `eof()` is `false`.
+/// See `readv` for a higher level function that has the same, familiar API as
+/// other read functions, such as `std.fs.File.read`.
+pub fn readvAdvanced(c: *Client, stream: std.net.Stream, iovecs: []const std.posix.iovec) !usize {
+    var vp: VecPut = .{ .iovecs = iovecs };
+
+    // Give away the buffered cleartext we have, if any.
+    if (c.cleartext_slice.len > 0) {
+        const amt: u15 = @intCast(vp.put(c.cleartext_slice));
+        c.cleartext_slice = c.cleartext_slice[amt..];
+
+        if (c.cleartext_slice.len == 0) {
+            // The buffer is now empty.
+        }
+
+        if (c.received_close_notify) {
+            c.ciphertext_slice = c.partially_read_buffer[0..0];
+            assert(vp.total == amt);
+            return amt;
+        } else if (amt > 0) {
+            // We don't need more data, so don't call read.
+            assert(vp.total == amt);
+            return amt;
+        }
+    }
+    assert(c.cleartext_slice.len == 0);
+
+    // Receive until we have a complete record
+    while (true) {
+        // Skip `stream.readv` if there is a complete record unprocessed
+        // This may happen when different types of traffic are mixed.
+        if (c.ciphertext_slice.len > 5) {
+            const record_len = mem.readInt(u16, c.ciphertext_slice[3..5], .big);
+            if (record_len + 5 <= c.ciphertext_slice.len)
+                break;
+        }
+
+        // Ensure c.partial_ciphertex_idx == 0
+        // Recoup `partially_read_buffer space`. This is necessary because it is assumed
+        // below that `frag0` is big enough to hold at least one record.
+        if (c.ciphertext_slice.len != 0) {
+            limitedOverlapCopy(
+                c.partially_read_buffer[0..c.ciphertext_slice.len],
+                c.ciphertext_slice,
+            );
+            c.ciphertext_slice = c.partially_read_buffer[0..c.ciphertext_slice.len];
+        }
+
+        const remaining_partial_buffer = c.partially_read_buffer[c.ciphertext_slice.len..];
+        assert(remaining_partial_buffer.len != 0);
+
+        var ask_iovecs_buf = [_]std.posix.iovec{
+            .{
+                .base = remaining_partial_buffer.ptr,
+                .len = remaining_partial_buffer.len,
+            },
+            // TODO: enable larger buffer
+        };
+
+        assert(!c.received_close_notify);
+        const received_len = try stream.readv(&ask_iovecs_buf);
+        c.ciphertext_slice = c.partially_read_buffer[0 .. c.ciphertext_slice.len + received_len];
+        if (received_len == 0) {
+            // This is either a truncation attack, a bug in the server, or an
+            // intentional omission of the close_notify message due to truncation
+            // detection handled above the TLS layer.
+            if (c.allow_truncation_attacks) {
+                // No point in reading anymore
+                c.received_close_notify = true;
+                break;
+            } else {
+                return error.TlsConnectionTruncated;
+            }
+        }
+    }
+
+    // Decrypt. Note that we return as soon as we see one complete record.
+    decrypt: {
+        var in: usize = 0;
+        const frag = c.ciphertext_slice;
+
+        // Ensure a complete record is in `frag`
+        const ct: tls.ContentType = @enumFromInt(frag[in]);
+        const legacy_version = mem.readInt(u16, frag[in..][1..3], .big);
+        const record_len = mem.readInt(u16, frag[in..][3..5], .big);
+        if (record_len > max_ciphertext_len) return error.TlsRecordOverflow;
+        if (record_len > max_cleartext_len)
+            std.debug.print("{}", .{record_len});
+        in += 5;
+        const end = in + record_len;
+        assert(end <= frag.len);
+
+        // Now decode a complete record in `frag`
+        switch (ct) {
+            .alert => {
+                if (in + 2 > frag.len) return error.TlsDecodeError;
+                const level: tls.AlertLevel = @enumFromInt(frag[in]);
+                const desc: tls.AlertDescription = @enumFromInt(frag[in + 1]);
+                _ = level;
+
+                try desc.toError();
+
+                assert(desc == tls.AlertDescription.close_notify);
+                c.received_close_notify = true;
+                c.ciphertext_slice = c.ciphertext_slice[end..];
+                break :decrypt;
+            },
+            // TODO: distinguish between these
+            .application_data, .handshake, .change_cipher_spec => {},
+            else => return error.TlsUnexpectedMessage,
+        }
+
+        // Ideally, this buffer would never be used. It is needed when `iovecs` are
+        // too small to fit the cleartext, which may be as large as `max_ciphertext_len`.
+        var cleartext_stack_buffer: [max_cleartext_len]u8 = undefined;
+        const cleartext = if (c.cipher) |cipher| switch (cipher) {
+            inline else => |*p| c: {
+                const P = @TypeOf(p.*);
+                const V = @Vector(P.AEAD.nonce_length, u8);
+                const ciphertext_len = record_len - P.AEAD.tag_length - P.explicit_nonce_len;
+                const explicit_nonce = frag[in..][0..P.explicit_nonce_len].*;
+                in += explicit_nonce.len;
+                const ciphertext = frag[in..][0..ciphertext_len];
+                in += ciphertext_len;
+                const auth_tag = frag[in..][0..P.AEAD.tag_length].*;
+                const pad = [1]u8{0} ** (P.AEAD.nonce_length - 8);
+                const seq_big = @as([8]u8, @bitCast(big(c.read_seq)));
+                var nonce: [P.AEAD.nonce_length]u8 = undefined;
+                if (explicit_nonce.len != 0) {
+                    const implicit_nonce_len = P.AEAD.nonce_length - explicit_nonce.len;
+                    nonce[0..implicit_nonce_len].* = p.server_iv[0..implicit_nonce_len].*;
+                    nonce[implicit_nonce_len..P.AEAD.nonce_length].* = explicit_nonce;
+                } else {
+                    const operand: V = pad ++ seq_big;
+                    nonce = @as(V, p.server_iv) ^ operand;
+                }
+                const out_buf = vp.peek();
+                const cleartext_buf = if (ciphertext.len <= out_buf.len)
+                    out_buf
+                else
+                    &cleartext_stack_buffer;
+                const cleartext = cleartext_buf[0..ciphertext.len];
+                const ad = seq_big ++
+                    [1]u8{@intFromEnum(ct)} ++
+                    int2(legacy_version) ++
+                    int2(@intCast(ciphertext_len));
+                P.AEAD.decrypt(cleartext, ciphertext, auth_tag, &ad, nonce, p.server_key) catch
+                    return error.TlsBadRecordMac;
+                break :c cleartext;
+            },
+        } else {
+            const cleartext = frag[in..][0..record_len];
+            const amt = vp.put(cleartext);
+            if (amt < cleartext.len) {
+                c.cleartext_slice = cleartext[amt..];
+            }
+            c.ciphertext_slice = c.ciphertext_slice[end..];
+            break :decrypt;
+        };
+
+        c.read_seq = try std.math.add(u64, c.read_seq, 1);
+
+        // Determine whether the output buffer or a stack
+        // buffer was used for storing the cleartext.
+        if (cleartext.ptr == &cleartext_stack_buffer) {
+            // Stack buffer was used, so we must copy to the output buffer.
+            if (c.cleartext_slice.len > 0) {
+                // We have already run out of room in iovecs. Continue
+                // appending to `partially_read_buffer`.
+                const cleartxt_end = @intFromPtr(c.cleartext_slice.ptr) -
+                    @intFromPtr(&c.partially_read_buffer[0]) + c.cleartext_slice.len;
+                @memcpy(
+                    c.partially_read_buffer[cleartxt_end..][0..cleartext.len],
+                    cleartext,
+                );
+                c.cleartext_slice.len += cleartext.len;
+                assert((c.cleartext_slice.ptr) == (&c.partially_read_buffer) and
+                    @intFromPtr(c.cleartext_slice.ptr) + c.cleartext_slice.len <=
+                    @intFromPtr(c.ciphertext_slice.ptr));
+            } else {
+                const amt = vp.put(cleartext);
+                if (amt < cleartext.len) {
+                    const rest = cleartext[amt..];
+                    c.cleartext_slice = c.partially_read_buffer[0..rest.len];
+                    limitedOverlapCopy(c.cleartext_slice, rest);
+                }
+            }
+        } else {
+            // Output buffer was used directly which means no
+            // memory copying needs to occur, and we can move
+            // on to the next ciphertext record.
+            vp.next(cleartext.len);
+        }
+        c.ciphertext_slice = c.ciphertext_slice[end..];
+    }
+    return vp.total;
+}
+
+/// `@memcpy(dst, src)` but allows `dst.ptr + dst.len <= src.ptr`
+fn limitedOverlapCopy(dst: []u8, src: []u8) void {
+    if (dst.len == 0 and src.len == 0) return;
+    if (@intFromPtr(dst.ptr) + dst.len <= @intFromPtr(src.ptr)) {
+        // A single, non-overlapping memcpy suffices.
+        @memcpy(dst, src);
+    } else {
+        // One memcpy call would overlap, so just do this instead.
+        std.mem.copyForwards(u8, dst, src);
+    }
+}
+
+const builtin = @import("builtin");
+const native_endian = builtin.cpu.arch.endian();
+
+inline fn big(x: anytype) @TypeOf(x) {
+    return switch (native_endian) {
+        .big => x,
+        .little => @byteSwap(x),
+    };
+}
+
+pub fn SchemeEcdsa(comptime scheme: tls.SignatureScheme) type {
+    return switch (scheme) {
+        .ecdsa_secp256r1_sha256 => crypto.sign.ecdsa.EcdsaP256Sha256,
+        .ecdsa_secp384r1_sha384 => crypto.sign.ecdsa.EcdsaP384Sha384,
+        else => @compileError("bad scheme"),
+    };
+}
+
+pub fn SchemeHash(comptime scheme: tls.SignatureScheme) type {
+    return switch (scheme) {
+        .rsa_pss_rsae_sha256 => crypto.hash.sha2.Sha256,
+        .rsa_pss_rsae_sha384 => crypto.hash.sha2.Sha384,
+        .rsa_pss_rsae_sha512 => crypto.hash.sha2.Sha512,
+
+        .rsa_pkcs1_sha1 => crypto.hash.Sha1,
+        .rsa_pkcs1_sha256 => crypto.hash.sha2.Sha256,
+        .rsa_pkcs1_sha384 => crypto.hash.sha2.Sha384,
+        .rsa_pkcs1_sha512 => crypto.hash.sha2.Sha512,
+        else => @compileError("bad scheme"),
+    };
+}
+
+pub const HashName = enum {
+    // sha1,
+    sha256,
+    sha384,
+    // sha512,
+};
+
+pub const MessageHashType = union(HashName) {
+    // sha1: crypto.hash.Sha1,
+    sha256: crypto.hash.sha2.Sha256,
+    sha384: crypto.hash.sha2.Sha384,
+    // sha512: crypto.hash.sha2.Sha512,
+};
+
+/// Abstraction for sending multiple byte buffers to a slice of iovecs.
+const VecPut = struct {
+    iovecs: []const std.posix.iovec,
+    idx: usize = 0,
+    off: usize = 0,
+    total: usize = 0,
+
+    /// Returns the amount actually put which is always equal to bytes.len
+    /// unless the vectors ran out of space.
+    fn put(vp: *VecPut, bytes: []const u8) usize {
+        if (vp.idx >= vp.iovecs.len) return 0;
+        var bytes_i: usize = 0;
+        while (true) {
+            const v = vp.iovecs[vp.idx];
+            const dest = v.base[vp.off..v.len];
+            const src = bytes[bytes_i..][0..@min(dest.len, bytes.len - bytes_i)];
+            @memcpy(dest[0..src.len], src);
+            bytes_i += src.len;
+            vp.off += src.len;
+            if (vp.off >= v.len) {
+                vp.off = 0;
+                vp.idx += 1;
+                if (vp.idx >= vp.iovecs.len) {
+                    vp.total += bytes_i;
+                    return bytes_i;
+                }
+            }
+            if (bytes_i >= bytes.len) {
+                vp.total += bytes_i;
+                return bytes_i;
+            }
+        }
+    }
+
+    /// Returns the next buffer that consecutive bytes can go into.
+    fn peek(vp: VecPut) []u8 {
+        if (vp.idx >= vp.iovecs.len) return &.{};
+        const v = vp.iovecs[vp.idx];
+        return v.base[vp.off..v.len];
+    }
+
+    // After writing to the result of peek(), one can call next() to
+    // advance the cursor.
+    fn next(vp: *VecPut, len: usize) void {
+        vp.total += len;
+        vp.off += len;
+        if (vp.off >= vp.iovecs[vp.idx].len) {
+            vp.off = 0;
+            vp.idx += 1;
+        }
+    }
+
+    fn freeSize(vp: VecPut) usize {
+        if (vp.idx >= vp.iovecs.len) return 0;
+        var total: usize = 0;
+        total += vp.iovecs[vp.idx].len - vp.off;
+        if (vp.idx + 1 >= vp.iovecs.len) return total;
+        for (vp.iovecs[vp.idx + 1 ..]) |v| total += v.len;
+        return total;
+    }
+};
+
+pub const cipher_suites = tls.enum_array(CipherSuite, &.{
+    .ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+    .ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+    .ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+    .ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+    .ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+    .ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+
+    // Legacy
+    .RSA_WITH_AES_128_GCM_SHA256,
+    .RSA_WITH_AES_256_GCM_SHA384,
+});
+
+pub const CipherSuite = enum(u16) {
+    // TLS 1.2 cipher suites equivalent to ones supported by TLS 1.3
+    // Key exchange: DHE/ECDHE/RSA(only with AES-GCM)
+    // Authentication: RSA/PSK/ECDSA(only with ECDHE)
+    // AEAD: AES_128_GCM_SHA256/AES_256_GCM_SHA384/CHACHA20_POLY1305_SHA256
+    RSA_WITH_AES_128_GCM_SHA256 = 0x009c,
+    RSA_WITH_AES_256_GCM_SHA384 = 0x009d,
+    DHE_RSA_WITH_AES_128_GCM_SHA256 = 0x009e,
+    DHE_RSA_WITH_AES_256_GCM_SHA384 = 0x009f,
+    DHE_PSK_WITH_AES_128_GCM_SHA256 = 0x00aa,
+    DHE_PSK_WITH_AES_256_GCM_SHA384 = 0x00ab,
+    ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 = 0xc02b,
+    ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 = 0xc02c,
+    ECDHE_RSA_WITH_AES_128_GCM_SHA256 = 0xc02f,
+    ECDHE_RSA_WITH_AES_256_GCM_SHA384 = 0xc030,
+    ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 = 0xcca8,
+    ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 = 0xcca9,
+    DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 = 0xccaa,
+    ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 = 0xccac,
+    DHE_PSK_WITH_CHACHA20_POLY1305_SHA256 = 0xccad,
+    ECDHE_PSK_WITH_AES_128_GCM_SHA256 = 0xd001,
+    ECDHE_PSK_WITH_AES_256_GCM_SHA384 = 0xd002,
+    _,
+};
+
+pub const HandshakeType = enum(u8) {
+    client_hello = 1,
+    server_hello = 2,
+    new_session_ticket = 4,
+    end_of_early_data = 5,
+    encrypted_extensions = 8,
+    certificate = 11,
+    server_key_exchange = 12,
+    certificate_request = 13,
+    server_hello_done = 14,
+    certificate_verify = 15,
+    client_key_exchange = 16,
+    finished = 20,
+    key_update = 24,
+    message_hash = 254,
+    _,
+};
+
+pub const ECCurveType = enum(u8) {
+    explicit_prime = 1, // deprecated by RFC 8422
+    explicit_char2 = 2, // deprecated by RFC 8422
+    named_curve = 3,
+    _,
+};
+
+pub const ExtensionType = enum(u16) {
+    server_name = 0,
+    supported_groups = 10,
+    ec_point_formats = 11,
+    signature_algorithms = 13,
+    extended_master_secret = 23,
+    supported_versions = 43,
+    renegotiation_info = 0xff01,
+    _,
+};
+
+pub inline fn extension(comptime et: ExtensionType, bytes: anytype) [2 + 2 + bytes.len]u8 {
+    return int2(@intFromEnum(et)) ++ array(1, bytes);
+}
+
+pub const ECPointFormat = enum(u8) {
+    uncompressed = 0,
+    ansiX962_compressed_prime = 1, // deprecated by RFC 8422
+    ansiX962_compressed_char2 = 2, // deprecated by RFC 8422
+    _,
+};
+
+pub fn getAEAD(cs: CipherSuite) tls.CipherSuite {
+    return switch (cs) {
+        .DHE_RSA_WITH_AES_128_GCM_SHA256 => .AES_128_GCM_SHA256,
+        .ECDHE_RSA_WITH_AES_128_GCM_SHA256 => .AES_128_GCM_SHA256,
+        .DHE_PSK_WITH_AES_128_GCM_SHA256 => .AES_128_GCM_SHA256,
+        .ECDHE_PSK_WITH_AES_128_GCM_SHA256 => .AES_128_GCM_SHA256,
+        .ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => .AES_128_GCM_SHA256,
+        .RSA_WITH_AES_128_GCM_SHA256 => .AES_128_GCM_SHA256,
+        .DHE_RSA_WITH_AES_256_GCM_SHA384 => .AES_256_GCM_SHA384,
+        .ECDHE_RSA_WITH_AES_256_GCM_SHA384 => .AES_256_GCM_SHA384,
+        .DHE_PSK_WITH_AES_256_GCM_SHA384 => .AES_256_GCM_SHA384,
+        .ECDHE_PSK_WITH_AES_256_GCM_SHA384 => .AES_256_GCM_SHA384,
+        .ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => .AES_256_GCM_SHA384,
+        .RSA_WITH_AES_256_GCM_SHA384 => .AES_256_GCM_SHA384,
+        .DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => .CHACHA20_POLY1305_SHA256,
+        .ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => .CHACHA20_POLY1305_SHA256,
+        .DHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => .CHACHA20_POLY1305_SHA256,
+        .ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256 => .CHACHA20_POLY1305_SHA256,
+        .ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => .CHACHA20_POLY1305_SHA256,
+        _ => unreachable,
+    };
+}
+
+pub fn messageHash(cs: tls.CipherSuite) HashName {
+    return switch (cs) {
+        .AES_128_GCM_SHA256 => .sha256,
+        .AES_256_GCM_SHA384 => .sha384,
+        .CHACHA20_POLY1305_SHA256 => .sha256,
+        else => unreachable,
+    };
+}
+
+pub fn ApplicationCipherT(comptime AeadType: type, comptime HashType: type, comptime explicit_nonce: usize) type {
+    return struct {
+        pub const AEAD = AeadType;
+        pub const Hash = HashType;
+        pub const Hmac = crypto.auth.hmac.Hmac(Hash);
+        pub const explicit_nonce_len = explicit_nonce;
+
+        client_key: [AEAD.key_length]u8,
+        server_key: [AEAD.key_length]u8,
+        // For AES_GCM in TLS 1.2, lower 8 bytes are explicit nonce
+        client_iv: [AEAD.nonce_length]u8,
+        server_iv: [AEAD.nonce_length]u8,
+    };
+}
+
+/// Encryption parameters for application traffic.
+pub const ApplicationCipher = union(enum) {
+    AES_128_GCM_SHA256: ApplicationCipherT(crypto.aead.aes_gcm.Aes128Gcm, crypto.hash.sha2.Sha256, 8),
+    AES_256_GCM_SHA384: ApplicationCipherT(crypto.aead.aes_gcm.Aes256Gcm, crypto.hash.sha2.Sha384, 8),
+    CHACHA20_POLY1305_SHA256: ApplicationCipherT(crypto.aead.chacha_poly.ChaCha20Poly1305, crypto.hash.sha2.Sha256, 0),
+};
+
+pub fn createApplicationCipher(comptime tag: tls.CipherSuite) ApplicationCipher {
+    return @unionInit(ApplicationCipher, @tagName(tag), .{
+        .client_key = undefined,
+        .server_key = undefined,
+        .client_iv = undefined,
+        .server_iv = undefined,
+    });
+}
+
+pub const KeyExchangeAlgorithm = enum { ECDHE, DHE, RSA };
+
+pub fn getKeyExchangeAlgorithm(cs: CipherSuite) KeyExchangeAlgorithm {
+    return switch (cs) {
+        .ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+        .ECDHE_PSK_WITH_AES_128_GCM_SHA256,
+        .ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        .ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+        .ECDHE_PSK_WITH_AES_256_GCM_SHA384,
+        .ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+        .ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        .ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256,
+        .ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+        => .ECDHE,
+        .DHE_RSA_WITH_AES_128_GCM_SHA256,
+        .DHE_PSK_WITH_AES_128_GCM_SHA256,
+        .DHE_RSA_WITH_AES_256_GCM_SHA384,
+        .DHE_PSK_WITH_AES_256_GCM_SHA384,
+        .DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+        .DHE_PSK_WITH_CHACHA20_POLY1305_SHA256,
+        => .DHE,
+        .RSA_WITH_AES_128_GCM_SHA256,
+        .RSA_WITH_AES_256_GCM_SHA384,
+        => .RSA,
+        _ => unreachable,
+    };
+}
+
+pub fn read_single_record(stream: *const std.net.Stream, stream_decoder: *tls.Decoder, record_decoder: *tls.Decoder, content_type: tls.ContentType, handshake_type: HandshakeType) !tls.Decoder {
+    if (record_decoder.eof()) {
+        try stream_decoder.readAtLeastOurAmt(stream, tls.record_header_len);
+        const ct = stream_decoder.decode(tls.ContentType);
+        // TODO: Check content type even without eof
+        if (ct != content_type) return error.TlsUnexpectedMessage;
+        const protocol_version = stream_decoder.decode(u16);
+        if (protocol_version != 0x0303) return error.TlsAlertProtocolVersion;
+        const record_len = stream_decoder.decode(u16);
+        record_decoder.* = stream_decoder.sub(record_len);
+    }
+    try record_decoder.ensure(4);
+    const hst = record_decoder.decode(HandshakeType);
+    if (hst != handshake_type) return error.TlsUnexpectedMessage;
+    const length = record_decoder.decode(u24);
+    // TODO: Handle fragmentation
+    const hsd = try record_decoder.sub(length);
+    return hsd;
+}
+
+// hmac: crypto.auth.hmac.sha2.HmacSha256/384
+fn PRF_inner(comptime Hmac: type, secret: []const u8, label: []const u8, seed: []const u8, output: []u8) void {
+    var i: u32 = 0;
+    const hash_len = Hmac.mac_length;
+    var a0: [hash_len]u8 = undefined;
+    var a1: [hash_len]u8 = undefined;
+    while (true) {
+        if (output.len <= i * hash_len) {
+            // we do not handle truncation here
+            assert(output.len == i * hash_len);
+            break;
+        }
+
+        // A(i) = hmac(secret, A(i-1))
+        // A(0) = _seed
+        {
+            var ctx = Hmac.init(secret);
+            if (i == 0) {
+                ctx.update(label);
+                ctx.update(seed);
+            } else {
+                ctx.update(&a0);
+            }
+            ctx.final(&a1);
+        }
+
+        // Output(i) = hmac(secret, A(i) + _seed)
+        // where _seed = label + seed for PRF
+        {
+            var ctx = Hmac.init(secret);
+            ctx.update(&a1);
+            ctx.update(label);
+            ctx.update(seed);
+            ctx.final(output[i * hash_len ..][0..hash_len]);
+        }
+        i += 1;
+        @memcpy(&a0, &a1);
+    }
+}
+
+pub fn PRF(comptime hmac: type, secret: []const u8, label: []const u8, seed: []const u8, comptime output_len: usize) [output_len]u8 {
+    const hash_len = hmac.mac_length;
+    const extra_len = if (output_len % hash_len == 0) 0 else hash_len - output_len % hash_len;
+    const buf_len = output_len + extra_len;
+    var buf: [buf_len]u8 = undefined;
+    PRF_inner(hmac, secret, label, seed, &buf);
+    return buf[0..output_len].*;
+}


### PR DESCRIPTION
replaces the TlsClient implementation with code taken from https://github.com/melonedo/zig-tls12.
this seems to work fine with TLSv1.2 compatible servers. it's pretty much a drop-in replacement.

also fixes compilation error due to invalid fields in timeval struct.

edit: reading through the commit history it seems that the .tv_sec and .tv_nsec fields were changed in some zig version. i don't know if the intended target is the latest dev branch of zig or stable 0.13.0, so it may be that those changes are unnecessary. apologies if they are.
